### PR TITLE
Make go_proto_library targets public

### DIFF
--- a/pkg/model/client.go
+++ b/pkg/model/client.go
@@ -23,7 +23,7 @@ var (
 	ErrExpired = errors.New("grant expired")
 
 	// ClientVersion of the client library.
-	ClientVersion = "1.0.0"
+	ClientVersion = "1.0.1"
 )
 
 // Ownership holds information about the grant state and expiration, as well as signals for

--- a/proto/atoms/splitter/BUILD.bazel
+++ b/proto/atoms/splitter/BUILD.bazel
@@ -22,7 +22,7 @@ go_proto_library(
     ],
     importpath = "go.atoms.co/splitter/pb",
     proto = ":splitter_proto",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [
         "//proto/atoms/splitter/lib/service/location",
         "//proto/atoms/splitter/lib/service/session",

--- a/proto/atoms/splitter/lib/service/location/BUILD.bazel
+++ b/proto/atoms/splitter/lib/service/location/BUILD.bazel
@@ -14,7 +14,7 @@ go_proto_library(
     name = "location_go_proto",
     importpath = "go.atoms.co/splitter/lib/service/location/pb",
     proto = ":location_proto",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 go_library(

--- a/proto/atoms/splitter/lib/service/session/BUILD.bazel
+++ b/proto/atoms/splitter/lib/service/session/BUILD.bazel
@@ -17,7 +17,7 @@ go_proto_library(
     name = "session_go_proto",
     importpath = "go.atoms.co/splitter/lib/service/session/pb",
     proto = ":session_proto",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = ["//proto/atoms/splitter/lib/service/location"],
 )
 

--- a/proto/atoms/splitter/private/BUILD.bazel
+++ b/proto/atoms/splitter/private/BUILD.bazel
@@ -23,7 +23,7 @@ go_proto_library(
     ],
     importpath = "go.atoms.co/splitter/pb/private",
     proto = ":private_proto",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [
         "//proto/atoms/splitter",
         "//proto/atoms/splitter/lib/service/location",


### PR DESCRIPTION
Need to open up access for clients that use Splitter proto messages.