### PR TITLE
Remove go_library targets to prevent conflicts

### DIFF
--- a/proto/atoms/splitter/BUILD.bazel
+++ b/proto/atoms/splitter/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_go//go:def.bzl", "go_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
@@ -15,7 +14,7 @@ proto_library(
 )
 
 go_proto_library(
-    name = "splitter_go_proto",
+    name = "splitter",
     compilers = [
         "@rules_go//proto:go_proto",
         "@rules_go//proto:go_grpc_v2",
@@ -27,11 +26,4 @@ go_proto_library(
         "//proto/atoms/splitter/lib/service/location",
         "//proto/atoms/splitter/lib/service/session",
     ],
-)
-
-go_library(
-    name = "splitter",
-    embed = [":splitter_go_proto"],
-    importpath = "go.atoms.co/splitter/pb",
-    visibility = ["//visibility:public"],
 )

--- a/proto/atoms/splitter/lib/service/location/BUILD.bazel
+++ b/proto/atoms/splitter/lib/service/location/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_go//go:def.bzl", "go_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
@@ -11,15 +10,8 @@ proto_library(
 )
 
 go_proto_library(
-    name = "location_go_proto",
+    name = "location",
     importpath = "go.atoms.co/splitter/lib/service/location/pb",
     proto = ":location_proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "location",
-    embed = [":location_go_proto"],
-    importpath = "go.atoms.co/splitter/lib/service/location/pb",
     visibility = ["//visibility:public"],
 )

--- a/proto/atoms/splitter/lib/service/session/BUILD.bazel
+++ b/proto/atoms/splitter/lib/service/session/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_go//go:def.bzl", "go_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
@@ -14,16 +13,9 @@ proto_library(
 )
 
 go_proto_library(
-    name = "session_go_proto",
+    name = "session",
     importpath = "go.atoms.co/splitter/lib/service/session/pb",
     proto = ":session_proto",
     visibility = ["//visibility:public"],
     deps = ["//proto/atoms/splitter/lib/service/location"],
-)
-
-go_library(
-    name = "session",
-    embed = [":session_go_proto"],
-    importpath = "go.atoms.co/splitter/lib/service/session/pb",
-    visibility = ["//visibility:public"],
 )

--- a/proto/atoms/splitter/private/BUILD.bazel
+++ b/proto/atoms/splitter/private/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_go//go:def.bzl", "go_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
@@ -16,7 +15,7 @@ proto_library(
 )
 
 go_proto_library(
-    name = "private_go_proto",
+    name = "private",
     compilers = [
         "@rules_go//proto:go_proto",
         "@rules_go//proto:go_grpc_v2",
@@ -29,11 +28,4 @@ go_proto_library(
         "//proto/atoms/splitter/lib/service/location",
         "//proto/atoms/splitter/lib/service/session",
     ],
-)
-
-go_library(
-    name = "private",
-    embed = [":private_go_proto"],
-    importpath = "go.atoms.co/splitter/pb/private",
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The conflicts can happen if client uses `go_proto_library` that uses Splitter protos and depends on Splitter client at the same time.