### PR TITLE
Upgrade golang to 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,10 +18,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24.12'
+        go-version: '1.26.2'
 
     - name: Build
-      run: GOEXPERIMENT=synctest go build -v ./...
+      run: go build -v ./...
 
     - name: Test
-      run: GOEXPERIMENT=synctest go test -v ./...
+      run: go test -v ./...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,7 @@ tar(
 
 oci_image(
     name = "image",
-    base = "@golang_1_24_12",
+    base = "@golang_1_26_2",
     labels = {
         "org.opencontainers.image.source": "https://github.com/atoms-co/splitter",
     },

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,12 +8,7 @@ bazel_dep(name = "rules_oci", version = "2.3.0")
 bazel_dep(name = "tar.bzl", version = "0.7.0")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.from_file(
-    experiments = [
-        "synctest",
-    ],
-    go_mod = "//:go.mod",
-)
+go_sdk.from_file(go_mod = "//:go.mod")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
@@ -38,9 +33,9 @@ use_repo(
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
-    name = "golang_1_24_12",
-    digest = "sha256:8b788ecf5fddb91cd04e532205d6411de68a08b510885bb8fb1c93f54c03f737",
-    image = "golang:1.24.9",
+    name = "golang_1_26_2",
+    digest = "sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716",
+    image = "golang:1.26.2",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",
@@ -48,7 +43,7 @@ oci.pull(
 )
 use_repo(
     oci,
-    "golang_1_24_12",
-    "golang_1_24_12_linux_amd64",
-    "golang_1_24_12_linux_arm64_v8",
+    "golang_1_26_2",
+    "golang_1_26_2_linux_amd64",
+    "golang_1_26_2_linux_arm64_v8",
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.atoms.co/splitter
 
-go 1.24.12
+go 1.26.2
 
 require github.com/Jille/grpc-multi-resolver v1.3.0
 
@@ -58,7 +58,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	go.atoms.co/iox v1.0.0
-	go.atoms.co/lib v1.0.1
+	go.atoms.co/lib v1.1.0
 	go.atoms.co/slicex v1.0.1
 	go.uber.org/multierr v1.11.0
 	google.golang.org/grpc v1.70.0

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.atoms.co/iox v1.0.0 h1:tSCyphSPh17TnjhZn5OaGScJcO5aac2acOjO9M76skE=
 go.atoms.co/iox v1.0.0/go.mod h1:2PpoGBhfToxA0U2UfXkDSskPMiUyQzKi9DZtANqolew=
-go.atoms.co/lib v1.0.1 h1:mvx2t/FzBe+o2613YtfMN1LgED16goaRRqhUDE5SM0I=
-go.atoms.co/lib v1.0.1/go.mod h1:z2tIaPspVz3j9lI0XfNGE8BpLhmpCIpGcg0k5RZ82Z4=
+go.atoms.co/lib v1.1.0 h1:y0ACxKzzG93r9BOHVBMbzzyL8U/laPA7mI2X5qKP7RU=
+go.atoms.co/lib v1.1.0/go.mod h1:z2tIaPspVz3j9lI0XfNGE8BpLhmpCIpGcg0k5RZ82Z4=
 go.atoms.co/slicex v1.0.1 h1:IRwavsWqcgL1fn2ylBa/+fJgWE7He28H5XQMi80wgnY=
 go.atoms.co/slicex v1.0.1/go.mod h1:le4qkj6I+WTrEXXtTRyKF+or6wI5wOL9NW3Atk/zr5E=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=

--- a/lib/service/session/client_test.go
+++ b/lib/service/session/client_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestClient_Establish(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		def := location.NewInstance(location.New("us-west2", "unknown"))
@@ -30,7 +30,7 @@ func TestClient_Establish(t *testing.T) {
 }
 
 func TestClient_Heartbeat(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		def := location.NewInstance(location.New("us-west2", "pod1"))
@@ -52,7 +52,7 @@ func TestClient_Heartbeat(t *testing.T) {
 }
 
 func TestClient_HeartbeatWithOption(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		def := location.NewInstance(location.New("us-west2", "pod1"))
@@ -73,7 +73,7 @@ func TestClient_HeartbeatWithOption(t *testing.T) {
 }
 
 func TestClient_ExpirationPending(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		def := location.NewInstance(location.New("us-west2", "unknown"))
@@ -92,7 +92,7 @@ func TestClient_ExpirationPending(t *testing.T) {
 }
 
 func TestClient_ExpirationPendingWithOption(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		def := location.NewInstance(location.New("us-west2", "unknown"))
@@ -111,7 +111,7 @@ func TestClient_ExpirationPendingWithOption(t *testing.T) {
 }
 
 func TestClient_ExpirationEstablished(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		def := location.NewInstance(location.New("us-west2", "pod1"))
@@ -139,7 +139,7 @@ func TestClient_ExpirationEstablished(t *testing.T) {
 }
 
 func TestClient_ExpirationEstablishedWithOption(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		def := location.NewInstance(location.New("us-west2", "pod1"))

--- a/lib/service/session/server_test.go
+++ b/lib/service/session/server_test.go
@@ -40,7 +40,7 @@ func TestServer_Established(t *testing.T) {
 func TestServer_Heartbeat(t *testing.T) {
 	ctx := context.Background()
 
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		msg := session.NewEstablishMessage("sid", client)
 		establish, _ := msg.Establish()
 		server, out, _ := session.NewServer(ctx, instance, establish)
@@ -58,7 +58,7 @@ func TestServer_Heartbeat(t *testing.T) {
 func TestServer_HeartbeatWithOption(t *testing.T) {
 	ctx := context.Background()
 
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		msg := session.NewEstablishMessage("sid", client)
 		establish, _ := msg.Establish()
 		server, out, _ := session.NewServer(ctx, instance, establish, session.WithServerKeepAliveTimeout(30*time.Second))
@@ -76,7 +76,7 @@ func TestServer_HeartbeatWithOption(t *testing.T) {
 func TestServer_ExpirationPending(t *testing.T) {
 	ctx := context.Background()
 
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		msg := session.NewEstablishMessage("sid", client)
 		establish, _ := msg.Establish()
 		server, _, _ := session.NewServer(ctx, instance, establish)
@@ -93,7 +93,7 @@ func TestServer_ExpirationPending(t *testing.T) {
 func TestServer_ExpirationPendingWithOption(t *testing.T) {
 	ctx := context.Background()
 
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		msg := session.NewEstablishMessage("sid", client)
 		establish, _ := msg.Establish()
 		server, _, _ := session.NewServer(ctx, instance, establish, session.WithServerKeepAliveTimeout(30*time.Second))
@@ -110,7 +110,7 @@ func TestServer_ExpirationPendingWithOption(t *testing.T) {
 func TestServer_CloseOnSecondEstablish(t *testing.T) {
 	ctx := context.Background()
 
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		in := make(chan session.Message, 1)
 		in <- session.NewEstablishMessage("sid", client)
 		msg := session.NewEstablishMessage("sid", client)
@@ -126,7 +126,7 @@ func TestServer_CloseOnSecondEstablish(t *testing.T) {
 func TestServer_CloseOnClose(t *testing.T) {
 	ctx := context.Background()
 
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		msg := session.NewEstablishMessage("sid", client)
 		establish, _ := msg.Establish()
 		server, _, _ := session.NewServer(ctx, instance, establish)

--- a/pkg/model/region_test.go
+++ b/pkg/model/region_test.go
@@ -41,7 +41,7 @@ func TestRegionProvider(t *testing.T) {
 }
 
 func TestLiveRegionProvider(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 

--- a/pkg/model/workpool.go
+++ b/pkg/model/workpool.go
@@ -141,7 +141,15 @@ func (p *WorkPool) join(ctx context.Context) {
 			p.lostCoordinator(ctx)
 		})
 
-		time.Sleep(time.Second + randx.Duration(time.Second)) // short random backoff on disconnect
+		backoff := time.Second + randx.Duration(time.Second) // short random backoff on disconnect if not draining
+		select {
+		case <-time.After(backoff):
+			break
+		case <-p.drain.Closed():
+			return
+		case <-wctx.Done():
+			return
+		}
 	}
 }
 

--- a/pkg/model/workpool_test.go
+++ b/pkg/model/workpool_test.go
@@ -48,7 +48,11 @@ func TestWorkpool(t *testing.T) {
 				}
 			},
 		)
-		defer w.Drain(time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
+
 		<-coordinatorCon.Connected.Closed()
 
 		msg := assertx.Element(t, coordinatorCon.In)
@@ -91,7 +95,11 @@ func TestWorkpool(t *testing.T) {
 				}
 			},
 		)
-		defer w.Drain(time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
+
 		<-coordinatorCon.Connected.Closed()
 
 		assertx.Element(t, coordinatorCon.In)                              // register
@@ -143,7 +151,11 @@ func TestWorkpool(t *testing.T) {
 				}
 			},
 		)
-		defer w.Drain(time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
+
 		<-coordinatorCon.Connected.Closed()
 
 		assertx.Element(t, coordinatorCon.In)                              // register
@@ -197,7 +209,11 @@ func TestWorkpool(t *testing.T) {
 				}
 			},
 		)
-		defer w.Drain(time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
+
 		<-coordinatorCon.Connected.Closed()
 
 		assertx.Element(t, coordinatorCon.In)                              // register
@@ -263,7 +279,11 @@ func TestWorkpool(t *testing.T) {
 				}
 			},
 		)
-		defer w.Drain(time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
+
 		<-coordinatorCon.Connected.Closed()
 
 		assertx.Element(t, coordinatorCon.In)                              // register
@@ -332,7 +352,11 @@ func TestWorkpool(t *testing.T) {
 				}
 			},
 		)
-		defer w.Drain(time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
+
 		<-coordinatorCon.Connected.Closed()
 
 		assertx.Element(t, coordinatorCon.In)                              // register
@@ -395,7 +419,11 @@ func TestWorkpool(t *testing.T) {
 				done.Close()
 			},
 		)
-		defer w.Drain(time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
+
 		<-coordinatorCon.Connected.Closed()
 
 		requirex.Element(t, coordinatorCon.In)                             // register
@@ -430,7 +458,11 @@ func TestWorkpool(t *testing.T) {
 				done.Close()
 			},
 		)
-		defer w.Drain(time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
+
 		<-coordinatorCon.Connected.Closed()
 
 		requirex.Element(t, coordinatorCon.In)                             // register
@@ -472,7 +504,10 @@ func TestWorkpool(t *testing.T) {
 				}
 			},
 		)
-		defer w.Drain(10 * time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
 
 		<-coordinatorCon.Connected.Closed()
 

--- a/pkg/service/coordinator/coordinator_test.go
+++ b/pkg/service/coordinator/coordinator_test.go
@@ -38,7 +38,7 @@ var (
 )
 
 func TestCoordinator_SingleConsumer(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		domain, err := model.NewDomain(domainName, model.Unit, time.Now())
@@ -86,7 +86,7 @@ func TestCoordinator_SingleConsumer(t *testing.T) {
 }
 
 func TestCoordinator_TwoConsumers(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		domain, err := model.NewDomain(domainName, model.Regional, time.Now(), model.WithDomainConfig(
@@ -219,7 +219,7 @@ func TestCoordinator_TwoConsumers(t *testing.T) {
 }
 
 func TestCoordinator_TwoConsumers_IgnoreLoadBalanceUnitDomain2(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		domain, err := model.NewDomain(domainName, model.Regional, time.Now(), model.WithDomainConfig(
@@ -297,7 +297,7 @@ func TestCoordinator_TwoConsumers_IgnoreLoadBalanceUnitDomain2(t *testing.T) {
 }
 
 func TestCoordinator_CapacityLimitConsumer(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		domain, err := model.NewDomain(domainName, model.Regional, time.Now(), model.WithDomainConfig(
@@ -344,7 +344,7 @@ func TestCoordinator_CapacityLimitConsumer(t *testing.T) {
 }
 
 func TestCoordinator_NamedKeyConsumers(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		names := []model.NamedDomainKey{
@@ -450,7 +450,7 @@ func TestCoordinator_NamedKeyConsumers(t *testing.T) {
 }
 
 func TestCoordinator_RevokeGrant(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 
 		ctx := context.Background()
 
@@ -553,7 +553,7 @@ func TestCoordinator_RevokeGrant(t *testing.T) {
 }
 
 func TestCoordinator_RelinquishGrant(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		domain, err := model.NewDomain(domainName, model.Global, time.Now(), model.WithDomainConfig(
@@ -594,7 +594,7 @@ func TestCoordinator_RelinquishGrant(t *testing.T) {
 }
 
 func TestCoordinator_CustomShards(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		initialShards := []model.ShardingPolicyShard{
@@ -662,7 +662,7 @@ func TestCoordinator_CustomShards(t *testing.T) {
 }
 
 func TestCoordinator_RegionSpecificShards(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		customShards := []model.ShardingPolicyShard{
@@ -743,7 +743,7 @@ func matchesRange(grants []model.Grant, ranges []uuidx.Range, region string) boo
 }
 
 func TestObserverConnection(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		coord := setup(ctx, t, []model.Domain{}, true)
@@ -774,7 +774,7 @@ func TestObserverConnection(t *testing.T) {
 }
 
 func TestObserverReceivesClusterUpdates(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		domain, err := model.NewDomain(domainName, model.Unit, time.Now())
@@ -819,7 +819,7 @@ func TestObserverReceivesClusterUpdates(t *testing.T) {
 }
 
 func TestMultipleObservers(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		domain, err := model.NewDomain(domainName, model.Unit, time.Now())
@@ -874,7 +874,7 @@ func TestMultipleObservers(t *testing.T) {
 }
 
 func TestCoordinator_ConsumerReconnectsWhileSuspended(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		domain, err := model.NewDomain(domainName, model.Regional, time.Now(), model.WithDomainConfig(
@@ -925,7 +925,7 @@ func TestCoordinator_ConsumerReconnectsWhileSuspended(t *testing.T) {
 }
 
 func TestCoordinator_ConsumerSuspendAndResume(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
 		domain, err := model.NewDomain(domainName, model.Regional, time.Now(), model.WithDomainConfig(

--- a/pkg/service/leader/leader_test.go
+++ b/pkg/service/leader/leader_test.go
@@ -97,7 +97,7 @@ func TestLeader_SingleWorkerReattach(t *testing.T) {
 }
 
 func TestLeader_MultipleWorker(t *testing.T) {
-	synctest.Run(func() {
+	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 		loc := location.New("centralus", "splitter-0")
 

--- a/pkg/service/worker/worker.go
+++ b/pkg/service/worker/worker.go
@@ -219,7 +219,15 @@ func (w *worker) join(ctx context.Context) {
 			w.lostLeader(ctx)
 		})
 
-		time.Sleep(time.Second + randx.Duration(time.Second)) // short random backoff on disconnect
+		backoff := time.Second + randx.Duration(time.Second) // short random backoff on disconnect if not draining
+		select {
+		case <-time.After(backoff):
+			break
+		case <-w.drain.Closed():
+			return
+		case <-wctx.Done():
+			return
+		}
 	}
 }
 

--- a/pkg/service/worker/worker_test.go
+++ b/pkg/service/worker/worker_test.go
@@ -29,8 +29,8 @@ var (
 )
 
 func TestWorker(t *testing.T) {
-	synctest.Run(func() {
-		ctx := context.Background()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
 
 		leaderCon := newFakeCon[leader.Message]()
 		defer leaderCon.Close()
@@ -53,13 +53,15 @@ func TestWorker(t *testing.T) {
 			return c
 		}
 		w, _ := worker.New(location.New("centralus", "pod1"), "endpoint", joinFn, coordFactory)
-		defer w.Drain(time.Second)
+		defer func() {
+			w.Drain(time.Second)
+			<-w.Closed()
+		}()
 
 		<-leaderCon.Connected.Closed()
 
 		// (1) Worker sends REGISTER
-
-		t.Run("register", func(t *testing.T) {
+		{
 			msg := assertx.Element(t, leaderCon.In)
 
 			// << register
@@ -73,11 +75,10 @@ func TestWorker(t *testing.T) {
 			// >> state (omitted) and lease
 
 			leaderCon.Out <- leader.NewLeaseUpdate(time.Now().Add(time.Minute))
-		})
+		}
 
 		// (2) Grant/Revoke
-
-		t.Run("grant", func(t *testing.T) {
+		{
 			// << grant from leader --> coordinator creation
 			grant := core.NewGrant("grant1", service1, time.Now().Add(time.Minute), time.Now())
 			leaderCon.Out <- leader.NewAssign(grant, core.State{})
@@ -105,11 +106,10 @@ func TestWorker(t *testing.T) {
 			upd := core.NewServiceUpdate(model.NewServiceInfo(service, 2, time.Now()))
 			leaderCon.Out <- leader.NewUpdate(grant2, upd)
 			assertx.Element(t, c.updates)
-		})
+		}
 
 		// (3) Worker disconnect and reconnect to Leader
-
-		t.Run("worker/disconnect", func(t *testing.T) {
+		{
 			// Shut down leader connection to force reconnect
 			oldLeaderCon := leaderCon
 			leaderCon = newFakeCon[leader.Message]()
@@ -125,11 +125,10 @@ func TestWorker(t *testing.T) {
 			register, ok := wMsg.Register()
 			assert.True(t, ok)
 			assert.Len(t, register.Active(), 1)
-		})
+		}
 
 		// (4) Consumer connects
-
-		t.Run("consumer/connect", func(t *testing.T) {
+		{
 			consumer := model.NewInstance(location.NewInstance(location.New("centralus", "node")), "endpoint")
 			in := chanx.NewFixed(model.NewRegister(consumer, service2, nil, nil))
 
@@ -139,7 +138,7 @@ func TestWorker(t *testing.T) {
 			in2 := chanx.NewFixed(model.NewRegister(consumer, service1, nil, nil))
 			_, err = w.Connect(ctx, session.NewID(), location.NewInstance(location.New("centralus", "splitter1")), in2)
 			assert.Error(t, err)
-		})
+		}
 	})
 
 }

--- a/pkg/service/worker/worker_test.go
+++ b/pkg/service/worker/worker_test.go
@@ -29,74 +29,30 @@ var (
 )
 
 func TestWorker(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		ctx := t.Context()
+	// (1) Grant/Revoke
+	t.Run("grant", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			d := setupWorkerTestDeps(t)
+			defer d.close()
 
-		leaderCon := newFakeCon[leader.Message]()
-		defer leaderCon.Close()
-
-		coordinators := make(chan *fakeCoordinator)
-		var cleanUpCoords []*fakeCoordinator
-		defer func() {
-			for _, c := range cleanUpCoords {
-				c.Close()
-			}
-		}()
-
-		joinFn := func(ctx context.Context, self location.Instance, handler grpcx.Handler[leader.Message, leader.Message]) error {
-			return leaderCon.connect(ctx, handler)
-		}
-		coordFactory := func(ctx context.Context, service model.QualifiedServiceName, state core.State, updates <-chan core.Update) coordinator.Coordinator {
-			c := newFakeCoordinator(service, updates)
-			cleanUpCoords = append(cleanUpCoords, c)
-			coordinators <- c
-			return c
-		}
-		w, _ := worker.New(location.New("centralus", "pod1"), "endpoint", joinFn, coordFactory)
-		defer func() {
-			w.Drain(time.Second)
-			<-w.Closed()
-		}()
-
-		<-leaderCon.Connected.Closed()
-
-		// (1) Worker sends REGISTER
-		{
-			msg := assertx.Element(t, leaderCon.In)
-
-			// << register
-			wMsg, ok := msg.WorkerMessage()
-			assert.True(t, ok)
-
-			register, ok := wMsg.Register()
-			assert.True(t, ok)
-			assert.Len(t, register.Active(), 0)
-
-			// >> state (omitted) and lease
-
-			leaderCon.Out <- leader.NewLeaseUpdate(time.Now().Add(time.Minute))
-		}
-
-		// (2) Grant/Revoke
-		{
 			// << grant from leader --> coordinator creation
 			grant := core.NewGrant("grant1", service1, time.Now().Add(time.Minute), time.Now())
-			leaderCon.Out <- leader.NewAssign(grant, core.State{})
-			assertx.Element(t, coordinators)
+			d.leaderConn.Out <- leader.NewAssign(grant, core.State{})
+			assertx.Element(t, d.coordinatorChan)
 
 			// << grant2 from leader --> coordinator creation
 
 			grant2 := core.NewGrant("grant2", service2, time.Now().Add(time.Minute), time.Now())
-			leaderCon.Out <- leader.NewAssign(grant2, core.State{})
-			c := assertx.Element(t, coordinators)
+			d.leaderConn.Out <- leader.NewAssign(grant2, core.State{})
+			c := assertx.Element(t, d.coordinatorChan)
 
 			// << revoke grant1 from leader --> relinquish
 
-			leaderCon.Out <- leader.NewRevoke(grant)
+			d.leaderConn.Out <- leader.NewRevoke(grant)
 
 			// >> relinquished
 
-			msg := assertx.Element(t, leaderCon.In)
+			msg := assertx.Element(t, d.leaderConn.In)
 			wMsg, ok := msg.WorkerMessage()
 			assert.True(t, ok)
 			assert.True(t, wMsg.IsRelinquished())
@@ -104,43 +60,61 @@ func TestWorker(t *testing.T) {
 			// update
 			service, _ := model.NewService(service2, time.Now())
 			upd := core.NewServiceUpdate(model.NewServiceInfo(service, 2, time.Now()))
-			leaderCon.Out <- leader.NewUpdate(grant2, upd)
+			d.leaderConn.Out <- leader.NewUpdate(grant2, upd)
 			assertx.Element(t, c.updates)
-		}
+		})
+	})
 
-		// (3) Worker disconnect and reconnect to Leader
-		{
+	// (2) Worker disconnect and reconnect to Leader
+	t.Run("worker/disconnect", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			d := setupWorkerTestDeps(t)
+			defer d.close()
+
+			// << grant from leader --> coordinator creation
+			grant := core.NewGrant("grant1", service1, time.Now().Add(time.Minute), time.Now())
+			d.leaderConn.Out <- leader.NewAssign(grant, core.State{})
+			assertx.Element(t, d.coordinatorChan)
+
 			// Shut down leader connection to force reconnect
-			oldLeaderCon := leaderCon
-			leaderCon = newFakeCon[leader.Message]()
+			oldLeaderCon := d.leaderConn
+			d.leaderConn = newFakeCon[leader.Message]()
 			oldLeaderCon.Close()
 
-			time.Sleep(2 * time.Second) // Random backoff
+			<-d.leaderConn.Connected.Closed()
 
-			<-leaderCon.Connected.Closed()
-
-			msg := assertx.Element(t, leaderCon.In)
+			// Worker should still hold grant
+			msg := assertx.Element(t, d.leaderConn.In)
 			wMsg, ok := msg.WorkerMessage()
 			assert.True(t, ok)
 			register, ok := wMsg.Register()
 			assert.True(t, ok)
 			assert.Len(t, register.Active(), 1)
-		}
+		})
+	})
 
-		// (4) Consumer connects
-		{
+	// (3) Consumer connects
+	t.Run("consumer/connect", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			d := setupWorkerTestDeps(t)
+			defer d.close()
+
+			// << grant2 from leader --> coordinator creation
+			grant2 := core.NewGrant("grant2", service2, time.Now().Add(time.Minute), time.Now())
+			d.leaderConn.Out <- leader.NewAssign(grant2, core.State{})
+			assertx.Element(t, d.coordinatorChan)
+
 			consumer := model.NewInstance(location.NewInstance(location.New("centralus", "node")), "endpoint")
 			in := chanx.NewFixed(model.NewRegister(consumer, service2, nil, nil))
 
-			_, err := w.Connect(ctx, session.NewID(), location.NewInstance(location.New("centralus", "splitter1")), in)
+			_, err := d.worker.Connect(d.ctx, session.NewID(), location.NewInstance(location.New("centralus", "wds1")), in)
 			require.NoError(t, err)
 
 			in2 := chanx.NewFixed(model.NewRegister(consumer, service1, nil, nil))
-			_, err = w.Connect(ctx, session.NewID(), location.NewInstance(location.New("centralus", "splitter1")), in2)
+			_, err = d.worker.Connect(d.ctx, session.NewID(), location.NewInstance(location.New("centralus", "wds1")), in2)
 			assert.Error(t, err)
-		}
+		})
 	})
-
 }
 
 type fakeCoordinator struct {
@@ -215,4 +189,65 @@ func (f *fakeCon[T]) connect(ctx context.Context, handler grpcx.Handler[T, T]) e
 	case <-ctx.Done():
 	}
 	return nil
+}
+
+type workerTestDeps struct {
+	t   *testing.T
+	ctx context.Context
+
+	leaderConn      *fakeCon[leader.Message]
+	coordinatorChan chan *fakeCoordinator
+	coordinators    []*fakeCoordinator
+	worker          worker.Worker
+}
+
+// setupWorkerTestDeps sets up dependencies and registers a worker for worker test.
+func setupWorkerTestDeps(t *testing.T) *workerTestDeps {
+	t.Helper()
+
+	d := &workerTestDeps{
+		t:               t,
+		ctx:             t.Context(),
+		leaderConn:      newFakeCon[leader.Message](),
+		coordinatorChan: make(chan *fakeCoordinator),
+	}
+
+	joinFn := func(ctx context.Context, self location.Instance, handler grpcx.Handler[leader.Message, leader.Message]) error {
+		return d.leaderConn.connect(ctx, handler)
+	}
+
+	coordFactory := func(ctx context.Context, service model.QualifiedServiceName, state core.State, updates <-chan core.Update) coordinator.Coordinator {
+		c := newFakeCoordinator(service, updates)
+		d.coordinators = append(d.coordinators, c)
+		d.coordinatorChan <- c
+		return c
+	}
+
+	d.worker, _ = worker.New(location.New("centralus", "pod1"), "endpoint", joinFn, coordFactory)
+	<-d.leaderConn.Connected.Closed()
+
+	msg := assertx.Element(t, d.leaderConn.In)
+
+	// << register
+	wMsg, ok := msg.WorkerMessage()
+	assert.True(t, ok)
+
+	register, ok := wMsg.Register()
+	assert.True(t, ok)
+	assert.Len(t, register.Active(), 0)
+
+	// >> state (omitted) and lease
+	d.leaderConn.Out <- leader.NewLeaseUpdate(time.Now().Add(time.Minute))
+	return d
+}
+
+func (d *workerTestDeps) close() {
+	for _, c := range d.coordinators {
+		c.Close()
+	}
+
+	d.worker.Drain(time.Second)
+	<-d.worker.Closed()
+
+	d.leaderConn.Close()
 }


### PR DESCRIPTION
This change
- Upgrades golang to `1.26.2`.
- Update `go.atoms.co/lib` to `v1.1.0`.