### PR TITLE
Implement RAFT add/remove

### DIFF
--- a/pb/private/cluster.pb.go
+++ b/pb/private/cluster.pb.go
@@ -109,6 +109,174 @@ func (*ClusterNotifyResponse) Descriptor() ([]byte, []int) {
 	return file_atoms_splitter_private_cluster_proto_rawDescGZIP(), []int{1}
 }
 
+type ClusterAddNodeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Address       string                 `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClusterAddNodeRequest) Reset() {
+	*x = ClusterAddNodeRequest{}
+	mi := &file_atoms_splitter_private_cluster_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClusterAddNodeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClusterAddNodeRequest) ProtoMessage() {}
+
+func (x *ClusterAddNodeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_atoms_splitter_private_cluster_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClusterAddNodeRequest.ProtoReflect.Descriptor instead.
+func (*ClusterAddNodeRequest) Descriptor() ([]byte, []int) {
+	return file_atoms_splitter_private_cluster_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ClusterAddNodeRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ClusterAddNodeRequest) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+type ClusterAddNodeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClusterAddNodeResponse) Reset() {
+	*x = ClusterAddNodeResponse{}
+	mi := &file_atoms_splitter_private_cluster_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClusterAddNodeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClusterAddNodeResponse) ProtoMessage() {}
+
+func (x *ClusterAddNodeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_atoms_splitter_private_cluster_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClusterAddNodeResponse.ProtoReflect.Descriptor instead.
+func (*ClusterAddNodeResponse) Descriptor() ([]byte, []int) {
+	return file_atoms_splitter_private_cluster_proto_rawDescGZIP(), []int{3}
+}
+
+type ClusterRemoveNodeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClusterRemoveNodeRequest) Reset() {
+	*x = ClusterRemoveNodeRequest{}
+	mi := &file_atoms_splitter_private_cluster_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClusterRemoveNodeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClusterRemoveNodeRequest) ProtoMessage() {}
+
+func (x *ClusterRemoveNodeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_atoms_splitter_private_cluster_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClusterRemoveNodeRequest.ProtoReflect.Descriptor instead.
+func (*ClusterRemoveNodeRequest) Descriptor() ([]byte, []int) {
+	return file_atoms_splitter_private_cluster_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ClusterRemoveNodeRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type ClusterRemoveNodeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClusterRemoveNodeResponse) Reset() {
+	*x = ClusterRemoveNodeResponse{}
+	mi := &file_atoms_splitter_private_cluster_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClusterRemoveNodeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClusterRemoveNodeResponse) ProtoMessage() {}
+
+func (x *ClusterRemoveNodeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_atoms_splitter_private_cluster_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClusterRemoveNodeResponse.ProtoReflect.Descriptor instead.
+func (*ClusterRemoveNodeResponse) Descriptor() ([]byte, []int) {
+	return file_atoms_splitter_private_cluster_proto_rawDescGZIP(), []int{5}
+}
+
 var File_atoms_splitter_private_cluster_proto protoreflect.FileDescriptor
 
 const file_atoms_splitter_private_cluster_proto_rawDesc = "" +
@@ -117,9 +285,19 @@ const file_atoms_splitter_private_cluster_proto_rawDesc = "" +
 	"\x14ClusterNotifyRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\"\x17\n" +
-	"\x15ClusterNotifyResponse2w\n" +
+	"\x15ClusterNotifyResponse\"A\n" +
+	"\x15ClusterAddNodeRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
+	"\aaddress\x18\x02 \x01(\tR\aaddress\"\x18\n" +
+	"\x16ClusterAddNodeResponse\"*\n" +
+	"\x18ClusterRemoveNodeRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\x1b\n" +
+	"\x19ClusterRemoveNodeResponse2\xd4\x02\n" +
 	"\x0eClusterService\x12e\n" +
-	"\x06Notify\x12,.atoms.splitter.private.ClusterNotifyRequest\x1a-.atoms.splitter.private.ClusterNotifyResponseB!Z\x1fgo.atoms.co/splitter/pb/privateb\x06proto3"
+	"\x06Notify\x12,.atoms.splitter.private.ClusterNotifyRequest\x1a-.atoms.splitter.private.ClusterNotifyResponse\x12h\n" +
+	"\aAddNode\x12-.atoms.splitter.private.ClusterAddNodeRequest\x1a..atoms.splitter.private.ClusterAddNodeResponse\x12q\n" +
+	"\n" +
+	"RemoveNode\x120.atoms.splitter.private.ClusterRemoveNodeRequest\x1a1.atoms.splitter.private.ClusterRemoveNodeResponseB!Z\x1fgo.atoms.co/splitter/pb/privateb\x06proto3"
 
 var (
 	file_atoms_splitter_private_cluster_proto_rawDescOnce sync.Once
@@ -133,16 +311,24 @@ func file_atoms_splitter_private_cluster_proto_rawDescGZIP() []byte {
 	return file_atoms_splitter_private_cluster_proto_rawDescData
 }
 
-var file_atoms_splitter_private_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_atoms_splitter_private_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_atoms_splitter_private_cluster_proto_goTypes = []any{
-	(*ClusterNotifyRequest)(nil),  // 0: atoms.splitter.private.ClusterNotifyRequest
-	(*ClusterNotifyResponse)(nil), // 1: atoms.splitter.private.ClusterNotifyResponse
+	(*ClusterNotifyRequest)(nil),      // 0: atoms.splitter.private.ClusterNotifyRequest
+	(*ClusterNotifyResponse)(nil),     // 1: atoms.splitter.private.ClusterNotifyResponse
+	(*ClusterAddNodeRequest)(nil),     // 2: atoms.splitter.private.ClusterAddNodeRequest
+	(*ClusterAddNodeResponse)(nil),    // 3: atoms.splitter.private.ClusterAddNodeResponse
+	(*ClusterRemoveNodeRequest)(nil),  // 4: atoms.splitter.private.ClusterRemoveNodeRequest
+	(*ClusterRemoveNodeResponse)(nil), // 5: atoms.splitter.private.ClusterRemoveNodeResponse
 }
 var file_atoms_splitter_private_cluster_proto_depIdxs = []int32{
 	0, // 0: atoms.splitter.private.ClusterService.Notify:input_type -> atoms.splitter.private.ClusterNotifyRequest
-	1, // 1: atoms.splitter.private.ClusterService.Notify:output_type -> atoms.splitter.private.ClusterNotifyResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
+	2, // 1: atoms.splitter.private.ClusterService.AddNode:input_type -> atoms.splitter.private.ClusterAddNodeRequest
+	4, // 2: atoms.splitter.private.ClusterService.RemoveNode:input_type -> atoms.splitter.private.ClusterRemoveNodeRequest
+	1, // 3: atoms.splitter.private.ClusterService.Notify:output_type -> atoms.splitter.private.ClusterNotifyResponse
+	3, // 4: atoms.splitter.private.ClusterService.AddNode:output_type -> atoms.splitter.private.ClusterAddNodeResponse
+	5, // 5: atoms.splitter.private.ClusterService.RemoveNode:output_type -> atoms.splitter.private.ClusterRemoveNodeResponse
+	3, // [3:6] is the sub-list for method output_type
+	0, // [0:3] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -159,7 +345,7 @@ func file_atoms_splitter_private_cluster_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_atoms_splitter_private_cluster_proto_rawDesc), len(file_atoms_splitter_private_cluster_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/private/cluster_grpc.pb.go
+++ b/pb/private/cluster_grpc.pb.go
@@ -19,7 +19,9 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ClusterService_Notify_FullMethodName = "/atoms.splitter.private.ClusterService/Notify"
+	ClusterService_Notify_FullMethodName     = "/atoms.splitter.private.ClusterService/Notify"
+	ClusterService_AddNode_FullMethodName    = "/atoms.splitter.private.ClusterService/AddNode"
+	ClusterService_RemoveNode_FullMethodName = "/atoms.splitter.private.ClusterService/RemoveNode"
 )
 
 // ClusterServiceClient is the client API for ClusterService service.
@@ -27,6 +29,8 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ClusterServiceClient interface {
 	Notify(ctx context.Context, in *ClusterNotifyRequest, opts ...grpc.CallOption) (*ClusterNotifyResponse, error)
+	AddNode(ctx context.Context, in *ClusterAddNodeRequest, opts ...grpc.CallOption) (*ClusterAddNodeResponse, error)
+	RemoveNode(ctx context.Context, in *ClusterRemoveNodeRequest, opts ...grpc.CallOption) (*ClusterRemoveNodeResponse, error)
 }
 
 type clusterServiceClient struct {
@@ -47,11 +51,33 @@ func (c *clusterServiceClient) Notify(ctx context.Context, in *ClusterNotifyRequ
 	return out, nil
 }
 
+func (c *clusterServiceClient) AddNode(ctx context.Context, in *ClusterAddNodeRequest, opts ...grpc.CallOption) (*ClusterAddNodeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ClusterAddNodeResponse)
+	err := c.cc.Invoke(ctx, ClusterService_AddNode_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *clusterServiceClient) RemoveNode(ctx context.Context, in *ClusterRemoveNodeRequest, opts ...grpc.CallOption) (*ClusterRemoveNodeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ClusterRemoveNodeResponse)
+	err := c.cc.Invoke(ctx, ClusterService_RemoveNode_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ClusterServiceServer is the server API for ClusterService service.
 // All implementations should embed UnimplementedClusterServiceServer
 // for forward compatibility.
 type ClusterServiceServer interface {
 	Notify(context.Context, *ClusterNotifyRequest) (*ClusterNotifyResponse, error)
+	AddNode(context.Context, *ClusterAddNodeRequest) (*ClusterAddNodeResponse, error)
+	RemoveNode(context.Context, *ClusterRemoveNodeRequest) (*ClusterRemoveNodeResponse, error)
 }
 
 // UnimplementedClusterServiceServer should be embedded to have
@@ -63,6 +89,12 @@ type UnimplementedClusterServiceServer struct{}
 
 func (UnimplementedClusterServiceServer) Notify(context.Context, *ClusterNotifyRequest) (*ClusterNotifyResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Notify not implemented")
+}
+func (UnimplementedClusterServiceServer) AddNode(context.Context, *ClusterAddNodeRequest) (*ClusterAddNodeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddNode not implemented")
+}
+func (UnimplementedClusterServiceServer) RemoveNode(context.Context, *ClusterRemoveNodeRequest) (*ClusterRemoveNodeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemoveNode not implemented")
 }
 func (UnimplementedClusterServiceServer) testEmbeddedByValue() {}
 
@@ -102,6 +134,42 @@ func _ClusterService_Notify_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ClusterService_AddNode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ClusterAddNodeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClusterServiceServer).AddNode(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClusterService_AddNode_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClusterServiceServer).AddNode(ctx, req.(*ClusterAddNodeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ClusterService_RemoveNode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ClusterRemoveNodeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClusterServiceServer).RemoveNode(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClusterService_RemoveNode_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClusterServiceServer).RemoveNode(ctx, req.(*ClusterRemoveNodeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ClusterService_ServiceDesc is the grpc.ServiceDesc for ClusterService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -112,6 +180,14 @@ var ClusterService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Notify",
 			Handler:    _ClusterService_Notify_Handler,
+		},
+		{
+			MethodName: "AddNode",
+			Handler:    _ClusterService_AddNode_Handler,
+		},
+		{
+			MethodName: "RemoveNode",
+			Handler:    _ClusterService_RemoveNode_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -5,22 +5,24 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/raft"
 	boltdb "github.com/hashicorp/raft-boltdb/v2"
 
+	"go.atoms.co/iox"
+	"go.atoms.co/lib/chanx"
 	"go.atoms.co/lib/log"
 	"go.atoms.co/lib/metrics"
-	"go.atoms.co/lib/chanx"
 	"go.atoms.co/lib/net/grpcx"
-	"go.atoms.co/iox"
 	"go.atoms.co/lib/syncx"
+	splitterprivatepb "go.atoms.co/splitter/pb/private"
 	"go.atoms.co/splitter/pkg/core"
 	"go.atoms.co/splitter/pkg/model"
 	"go.atoms.co/splitter/pkg/service/leader"
-	splitterprivatepb "go.atoms.co/splitter/pb/private"
 )
 
 const (
@@ -28,6 +30,7 @@ const (
 	notifyInterval   = 30 * time.Second
 	notifyTimeout    = 10 * time.Second
 	bootstrapTimeout = 1 * time.Minute
+	forwardTimeout   = 35 * time.Second
 )
 
 var (
@@ -50,6 +53,8 @@ type Cluster interface {
 	iox.RAsyncCloser
 
 	Notify(ctx context.Context, id string, address string) error
+	AddNode(ctx context.Context, id string, address string) error
+	RemoveNode(ctx context.Context, id string) error
 	Info(ctx context.Context) map[string]string
 	Drain(timeout time.Duration)
 }
@@ -63,11 +68,13 @@ type cluster struct {
 	ldb, sdb *boltdb.BoltStore
 	trans    *raft.NetworkTransport
 	peers    []string
+	port     int
 
 	observer *raft.Observer
 	leaderCh <-chan leader.Directive
 
 	fastBootstrap bool
+	joiningNode   bool
 	drain         iox.AsyncCloser
 
 	inject       chan func()
@@ -85,6 +92,7 @@ func New(id raft.ServerID, addr raft.ServerAddress, r *raft.Raft, ldb, sdb *bolt
 		sdb:         sdb,
 		trans:       trans,
 		peers:       peers,
+		port:        port,
 		drain:       iox.NewAsyncCloser(),
 		inject:      make(chan func()),
 		notified:    make(map[raft.ServerID]raft.ServerAddress),
@@ -92,6 +100,7 @@ func New(id raft.ServerID, addr raft.ServerAddress, r *raft.Raft, ldb, sdb *bolt
 	for _, fn := range opts {
 		fn(c)
 	}
+	c.joiningNode = !c.isBootstrappedPeer(string(c.id))
 
 	observeCh := make(chan raft.Observation)
 	observer := raft.NewObserver(observeCh, true, func(o *raft.Observation) bool {
@@ -199,6 +208,92 @@ func (c *cluster) Notify(ctx context.Context, id string, address string) error {
 	return nil
 }
 
+// AddNode handles an incoming add request from a new node. If the current node is the RAFT leader, it adds the
+// voter. Otherwise, it forwards the request to the current leader.
+func (c *cluster) AddNode(ctx context.Context, id string, address string) error {
+	log.Infof(ctx, "Received add request: %v@%v", id, address)
+
+	leaderAddr, leaderID := c.raft.LeaderWithID()
+	if leaderID == "" {
+		return fmt.Errorf("no leader available")
+	}
+
+	if leaderID != c.id {
+		return c.forwardToLeader(ctx, leaderAddr, func(ctx context.Context, client splitterprivatepb.ClusterServiceClient) error {
+			_, err := client.AddNode(ctx, &splitterprivatepb.ClusterAddNodeRequest{Id: id, Address: address})
+			return err
+		})
+	}
+
+	future := c.raft.AddVoter(raft.ServerID(id), raft.ServerAddress(address), 0, 30*time.Second)
+	if err := future.Error(); err != nil {
+		return fmt.Errorf("failed to add voter %v: %w", id, err)
+	}
+
+	log.Infof(ctx, "Successfully added voter %v@%v", id, address)
+	return nil
+}
+
+// RemoveNode handles an incoming remove request. If this node is the RAFT leader, it removes the
+// node. Otherwise, it forwards the request to the current leader.
+func (c *cluster) RemoveNode(ctx context.Context, id string) error {
+	log.Infof(ctx, "Received remove request: %v", id)
+
+	if c.isBootstrappedPeer(id) {
+		return fmt.Errorf("cannot remove bootstrap peer %v", id)
+	}
+
+	leaderAddr, leaderID := c.raft.LeaderWithID()
+	if leaderID == "" {
+		return fmt.Errorf("no leader available")
+	}
+
+	if leaderID != c.id {
+		return c.forwardToLeader(ctx, leaderAddr, func(ctx context.Context, client splitterprivatepb.ClusterServiceClient) error {
+			_, err := client.RemoveNode(ctx, &splitterprivatepb.ClusterRemoveNodeRequest{Id: id})
+			return err
+		})
+	}
+
+	if id == string(c.id) {
+		log.Infof(ctx, "Leader is leaving, transferring leadership")
+		if err := c.raft.LeadershipTransfer().Error(); err != nil {
+			return fmt.Errorf("failed to transfer leadership: %w", err)
+		}
+
+		return raft.ErrNotLeader
+	}
+
+	future := c.raft.RemoveServer(raft.ServerID(id), 0, 30*time.Second)
+	if err := future.Error(); err != nil {
+		return fmt.Errorf("failed to remove server %v: %w", id, err)
+	}
+
+	log.Infof(ctx, "Successfully removed server %v", id)
+	return nil
+}
+
+// forwardToLeader forwards a request to the current RAFT leader.
+func (c *cluster) forwardToLeader(ctx context.Context, leaderAddr raft.ServerAddress, fn func(context.Context, splitterprivatepb.ClusterServiceClient) error) error {
+	host, _, err := net.SplitHostPort(string(leaderAddr))
+	if err != nil {
+		return fmt.Errorf("unexpected leader address %v: %w", leaderAddr, err)
+	}
+	endpoint := fmt.Sprintf("%v:%v", host, c.port)
+
+	ctx, cancel := context.WithTimeout(ctx, forwardTimeout)
+	defer cancel()
+
+	cc, err := grpcx.DialNonBlocking(ctx, endpoint, grpcx.WithInsecure())
+	if err != nil {
+		return fmt.Errorf("failed to dial leader %v: %w", endpoint, err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	log.Infof(ctx, "Not leader, forwarding to leader %v", endpoint)
+	return fn(ctx, splitterprivatepb.NewClusterServiceClient(cc))
+}
+
 func (c *cluster) Info(ctx context.Context) map[string]string {
 	return c.raft.Stats()
 }
@@ -212,6 +307,18 @@ func (c *cluster) init(ctx context.Context, observeCh chan raft.Observation) {
 	defer c.Close()
 	defer close(observeCh) // closes c.leaderCh
 
+	if c.joiningNode {
+		// Joining node: RAFT is running but this node may not be part of the cluster yet.
+		// An operator must call the Join RPC on an existing peer to add it.
+		// On restart, RAFT reconnects automatically via TCP transport.
+		log.Infof(ctx, "Node %v is not a bootstrap peer, waiting for manual join or reconnect", c.id)
+		c.process(ctx)
+	} else {
+		c.bootstrapCluster(ctx)
+	}
+}
+
+func (c *cluster) bootstrapCluster(ctx context.Context) {
 	notifyTicker := time.NewTicker(notifyInterval)
 	defer notifyTicker.Stop()
 
@@ -337,6 +444,15 @@ func (c *cluster) shutdownRaft(ctx context.Context) error {
 		return fmt.Errorf("failed to shutdown raft stable store cleanly: %w", err)
 	}
 	return nil
+}
+
+// isBootstrappedPeer returns true if the given raft ID matches one of the peers in the static peer list.
+// Assumes peers are DNS names of the form <raft-id>.<domain>:<port> and that --raft_id equals the
+// pod HOSTNAME. These assumptions hold for the existing bootstrap flow.
+func (c *cluster) isBootstrappedPeer(id string) bool {
+	return slices.ContainsFunc(c.peers, func(peer string) bool {
+		return strings.HasPrefix(peer, id+".") || peer == id
+	})
 }
 
 // txn runs the given function in the main thread sync. Any signal that triggers a complex action must

--- a/pkg/service/frontend/cluster.go
+++ b/pkg/service/frontend/cluster.go
@@ -3,8 +3,8 @@ package frontend
 import (
 	"context"
 
-	"go.atoms.co/splitter/pkg/cluster"
 	splitterprivatepb "go.atoms.co/splitter/pb/private"
+	"go.atoms.co/splitter/pkg/cluster"
 )
 
 type ClusterService struct {
@@ -22,4 +22,18 @@ func (r *ClusterService) Notify(ctx context.Context, req *splitterprivatepb.Clus
 		return nil, err
 	}
 	return &splitterprivatepb.ClusterNotifyResponse{}, nil
+}
+
+func (r *ClusterService) AddNode(ctx context.Context, req *splitterprivatepb.ClusterAddNodeRequest) (*splitterprivatepb.ClusterAddNodeResponse, error) {
+	if err := r.cluster.AddNode(ctx, req.GetId(), req.GetAddress()); err != nil {
+		return nil, err
+	}
+	return &splitterprivatepb.ClusterAddNodeResponse{}, nil
+}
+
+func (r *ClusterService) RemoveNode(ctx context.Context, req *splitterprivatepb.ClusterRemoveNodeRequest) (*splitterprivatepb.ClusterRemoveNodeResponse, error) {
+	if err := r.cluster.RemoveNode(ctx, req.GetId()); err != nil {
+		return nil, err
+	}
+	return &splitterprivatepb.ClusterRemoveNodeResponse{}, nil
 }

--- a/proto/atoms/splitter/private/cluster.proto
+++ b/proto/atoms/splitter/private/cluster.proto
@@ -12,10 +12,29 @@ message ClusterNotifyRequest {
 message ClusterNotifyResponse {
 }
 
+message ClusterAddNodeRequest {
+  string id = 1;
+  string address = 2;
+}
+
+message ClusterAddNodeResponse {}
+
+message ClusterRemoveNodeRequest {
+  string id = 1;
+}
+
+message ClusterRemoveNodeResponse {}
+
 // ClusterService is the internal service for RAFT cluster communication.
 service ClusterService {
   // Notify is an idempotent API designed for bootstrapping a RAFT cluster. Upon startup, Splitter instances will enter a
   // bootstrapping phase in which notifications will be sent out to all instances in an initial static list. When one
   // instance receives notifications from all instances, it will attempt to Bootstrap a RAFT cluster.
   rpc Notify (ClusterNotifyRequest) returns (ClusterNotifyResponse);
+
+  // AddNode adds a new node to the RAFT cluster.
+  rpc AddNode (ClusterAddNodeRequest) returns (ClusterAddNodeResponse);
+
+  // RemoveNode removes a node from the RAFT cluster.
+  rpc RemoveNode (ClusterRemoveNodeRequest) returns (ClusterRemoveNodeResponse);
 }


### PR DESCRIPTION
Splitter didn't support scaling up, it relied on a static peer list provided to it when the cluster is bootstrapped. To add more peers we would have needed to update the peer list in helm and redeploy. This specially could be useful in cases when a region is down or multiple pods are degraded but quorum is maintained. Adding a new node works if there's a leader, if multiple regions are down and quorum is broken adding a new node won't work.

New pods detect whether they are bootstrap members by matching their RAFT ID (pod hostname) against the first DNS label of each configured peer. If no match is found, the node starts as a lame duck, RAFT is running but the
node is not part of the cluster until an operator adds it.

Add flow: a manual operation will call raft-add. The request can be sent to any peer; if the contacted node is not the leader, it forwards the request to the current leader, so the caller doesn't need to know which node is the leader. On restart, the node reconnects automatically via RAFT's TCP transport.

Remove flow: a manual operation will call raft-remove to remove a node from the RAFT cluster. As with add, the request can be sent to any peer and is forwarded to the leader. This should be done before scaling down the
StatefulSet.