### PR TITLE
Refresh named-shard placement after detaching consumers

### DIFF
--- a/pkg/service/coordinator/coordinator.go
+++ b/pkg/service/coordinator/coordinator.go
@@ -450,17 +450,17 @@ func (c *coordinator) disconnect(ctx context.Context, reason string, consumers .
 		log.Infof(ctx, "Disconnecting consumer (reason: %v): %v", reason, s)
 		c.recordAction(ctx, "disconnect", "ok")
 
-		if len(s.consumer.Keys()) > 0 {
-			// Refresh allocation rules on disconnect if using named keys
-			c.refresh(ctx, 0)
-		}
-
 		if c.alloc.Detach(s.consumer.ID()) {
 			assigned := c.alloc.Assigned(s.ID())
 			if len(assigned.Active) > 0 || len(assigned.Allocated) > 0 {
 				log.Warnf(ctx, "Detached consumer %v with %v active and %v allocated domains", s.consumer, len(assigned.Active), len(assigned.Allocated))
 			}
 		} // else: already detached
+
+		if len(s.consumer.Keys()) > 0 {
+			// Refresh allocation rules on disconnect if using named keys
+			c.refresh(ctx, 0)
+		}
 
 		s.connection.Disconnect()
 		delete(c.consumers, s.consumer.ID())
@@ -704,6 +704,9 @@ func (c *coordinator) refresh(ctx context.Context, delay time.Duration) {
 	var isKeys bool
 	var keys []model.QualifiedDomainKey
 	for _, worker := range c.alloc.Workers() {
+		if worker.State != allocation.Attached {
+			continue
+		}
 		if len(worker.Instance.Data.Keys()) > 0 {
 			isKeys = true
 			keys = append(keys, worker.Instance.Data.Keys()...)

--- a/pkg/service/coordinator/coordinator_test.go
+++ b/pkg/service/coordinator/coordinator_test.go
@@ -451,6 +451,59 @@ func TestCoordinator_NamedKeyConsumers(t *testing.T) {
 	})
 }
 
+func TestCoordinator_NamedKeyDisconnectDropsNamedShardPenalty(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+
+		name := model.NamedDomainKey{Name: "test", Key: model.DomainKey{Region: "centralus", Key: model.MustParseKey("b188ea31-f889-4ce5-9fc9-77fda8ab5c83")}}
+		domain, err := model.NewDomain(domainName, model.Regional, time.Now(), model.WithDomainConfig(model.NewDomainConfig(model.WithDomainShardingPolicy(model.NewShardingPolicy(4)), model.WithDomainRegions("centralus"), model.WithDomainNamedKeys(name))))
+		require.NoError(t, err)
+
+		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		c := coord.(*coordinator)
+
+		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
+		in := make(chan model.ConsumerMessage, 1)
+		in <- model.NewRegister(w, serviceName, nil, nil)
+		out, err := coord.Connect(ctx, session.NewID(), location.NewInstance(location.New("centralus", "splitter1")), in)
+		require.NoError(t, err, "consumer failed to join coordinator")
+		defer func() {
+			coord.Close()
+			assertx.Closed(t, out)
+		}()
+
+		readFn(t, out, isClusterSnapshot)
+		for i := 0; i < 4; i++ {
+			assign := readFn(t, out, isAssign)
+			require.Len(t, assign.Grants(), 1)
+		}
+
+		_, load := c.alloc.Load()
+		require.Zero(t, load.Place)
+
+		w2 := model.NewInstance(location.NewInstance(location.New("centralus", "pod2")), "endpoint2")
+		in2 := make(chan model.ConsumerMessage, 1)
+		in2 <- model.NewRegister(w2, serviceName, nil, nil, model.WithKeyNames(model.DomainKeyName{Domain: domainName.Domain, Name: "test"}))
+		out2, err := coord.Connect(ctx, session.NewID(), location.NewInstance(location.New("centralus", "splitter1")), in2)
+		require.NoError(t, err, "consumer failed to join coordinator")
+
+		readFn(t, out2, isClusterSnapshot)
+		_, load = c.alloc.Load()
+		require.EqualValues(t, 20, load.Place, "matching shard should be marked as named")
+
+		close(in2)
+		synctest.Wait()
+		assertx.Closed(t, out2)
+
+		namedWorker, ok := c.alloc.Worker(w2.ID())
+		require.True(t, ok, "detached worker should remain until lease expiry")
+		require.Equal(t, "detached", string(namedWorker.State))
+
+		_, load = c.alloc.Load()
+		assert.Zero(t, load.Place, "disconnected consumer should stop influencing named-shard placement")
+	})
+}
+
 func TestCoordinator_RevokeGrant(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 


### PR DESCRIPTION
On disconnect, the coordinator refreshed placement rules before detaching the consumer. refresh also scanned all allocator workers, including detached workers. As a result, a disconnected named-key consumer could keep its keys in the derived named-shard rule, leaving placement penalties active even though the consumer was gone. The test fails without the fix.