### PR TITLE
[Splitter] Load tracking part 2 - Coordinator reports status to leader

### DIFF
--- a/pb/management.pb.go
+++ b/pb/management.pb.go
@@ -609,6 +609,7 @@ type Service_Config struct {
 	DefaultShardingPolicy *ShardingPolicy                    `protobuf:"bytes,2,opt,name=default_sharding_policy,json=defaultShardingPolicy,proto3" json:"default_sharding_policy,omitempty"`
 	Overrides             []*Service_Config_LocalityOverride `protobuf:"bytes,3,rep,name=overrides,proto3" json:"overrides,omitempty"`
 	Regions               []string                           `protobuf:"bytes,4,rep,name=regions,proto3" json:"regions,omitempty"`
+	TrackLoad             bool                               `protobuf:"varint,5,opt,name=track_load,json=trackLoad,proto3" json:"track_load,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -669,6 +670,13 @@ func (x *Service_Config) GetRegions() []string {
 		return x.Regions
 	}
 	return nil
+}
+
+func (x *Service_Config) GetTrackLoad() bool {
+	if x != nil {
+		return x.TrackLoad
+	}
+	return false
 }
 
 type Service_Operational struct {
@@ -996,17 +1004,19 @@ const file_atoms_splitter_management_proto_rawDesc = "" +
 	"TenantInfo\x12.\n" +
 	"\x06tenant\x18\x01 \x01(\v2\x16.atoms.splitter.TenantR\x06tenant\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\x03R\aversion\x128\n" +
-	"\ttimestamp\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xe6\x05\n" +
+	"\ttimestamp\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\x85\x06\n" +
 	"\aService\x128\n" +
 	"\x04name\x18\x01 \x01(\v2$.atoms.splitter.QualifiedServiceNameR\x04name\x126\n" +
 	"\x06config\x18\x02 \x01(\v2\x1e.atoms.splitter.Service.ConfigR\x06config\x124\n" +
 	"\acreated\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\acreated\x12E\n" +
-	"\voperational\x18\x04 \x01(\v2#.atoms.splitter.Service.OperationalR\voperational\x1a\xc1\x02\n" +
+	"\voperational\x18\x04 \x01(\v2#.atoms.splitter.Service.OperationalR\voperational\x1a\xe0\x02\n" +
 	"\x06Config\x12\x16\n" +
 	"\x06region\x18\x01 \x01(\tR\x06region\x12V\n" +
 	"\x17default_sharding_policy\x18\x02 \x01(\v2\x1e.atoms.splitter.ShardingPolicyR\x15defaultShardingPolicy\x12M\n" +
 	"\toverrides\x18\x03 \x03(\v2/.atoms.splitter.Service.Config.LocalityOverrideR\toverrides\x12\x18\n" +
-	"\aregions\x18\x04 \x03(\tR\aregions\x1a^\n" +
+	"\aregions\x18\x04 \x03(\tR\aregions\x12\x1d\n" +
+	"\n" +
+	"track_load\x18\x05 \x01(\bR\ttrackLoad\x1a^\n" +
 	"\x10LocalityOverride\x12!\n" +
 	"\fshard_region\x18\x01 \x01(\tR\vshardRegion\x12'\n" +
 	"\x0fconsumer_region\x18\x02 \x01(\tR\x0econsumerRegion\x1a\xa7\x01\n" +

--- a/pb/private/leader.pb.go
+++ b/pb/private/leader.pb.go
@@ -1536,6 +1536,7 @@ type WorkerMessage struct {
 	//	*WorkerMessage_Update_
 	//	*WorkerMessage_Revoke_
 	//	*WorkerMessage_Relinquished_
+	//	*WorkerMessage_ServiceStatus_
 	Msg           isWorkerMessage_Msg `protobuf_oneof:"msg"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1641,6 +1642,15 @@ func (x *WorkerMessage) GetRelinquished() *WorkerMessage_Relinquished {
 	return nil
 }
 
+func (x *WorkerMessage) GetServiceStatus() *WorkerMessage_ServiceStatus {
+	if x != nil {
+		if x, ok := x.Msg.(*WorkerMessage_ServiceStatus_); ok {
+			return x.ServiceStatus
+		}
+	}
+	return nil
+}
+
 type isWorkerMessage_Msg interface {
 	isWorkerMessage_Msg()
 }
@@ -1673,6 +1683,10 @@ type WorkerMessage_Relinquished_ struct {
 	Relinquished *WorkerMessage_Relinquished `protobuf:"bytes,7,opt,name=relinquished,proto3,oneof"`
 }
 
+type WorkerMessage_ServiceStatus_ struct {
+	ServiceStatus *WorkerMessage_ServiceStatus `protobuf:"bytes,9,opt,name=service_status,json=serviceStatus,proto3,oneof"`
+}
+
 func (*WorkerMessage_Register_) isWorkerMessage_Msg() {}
 
 func (*WorkerMessage_Deregister_) isWorkerMessage_Msg() {}
@@ -1686,6 +1700,8 @@ func (*WorkerMessage_Update_) isWorkerMessage_Msg() {}
 func (*WorkerMessage_Revoke_) isWorkerMessage_Msg() {}
 
 func (*WorkerMessage_Relinquished_) isWorkerMessage_Msg() {}
+
+func (*WorkerMessage_ServiceStatus_) isWorkerMessage_Msg() {}
 
 type ClusterMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2297,6 +2313,50 @@ func (x *WorkerMessage_Relinquished) GetGrants() []*Grant {
 	return nil
 }
 
+type WorkerMessage_ServiceStatus struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Load          *ServiceLoadInfo       `protobuf:"bytes,1,opt,name=load,proto3" json:"load,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerMessage_ServiceStatus) Reset() {
+	*x = WorkerMessage_ServiceStatus{}
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerMessage_ServiceStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerMessage_ServiceStatus) ProtoMessage() {}
+
+func (x *WorkerMessage_ServiceStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerMessage_ServiceStatus.ProtoReflect.Descriptor instead.
+func (*WorkerMessage_ServiceStatus) Descriptor() ([]byte, []int) {
+	return file_atoms_splitter_private_leader_proto_rawDescGZIP(), []int{13, 7}
+}
+
+func (x *WorkerMessage_ServiceStatus) GetLoad() *ServiceLoadInfo {
+	if x != nil {
+		return x.Load
+	}
+	return nil
+}
+
 type ClusterMessage_Assignment struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Worker        *pb.Instance           `protobuf:"bytes,1,opt,name=worker,proto3" json:"worker,omitempty"`
@@ -2307,7 +2367,7 @@ type ClusterMessage_Assignment struct {
 
 func (x *ClusterMessage_Assignment) Reset() {
 	*x = ClusterMessage_Assignment{}
-	mi := &file_atoms_splitter_private_leader_proto_msgTypes[24]
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2319,7 +2379,7 @@ func (x *ClusterMessage_Assignment) String() string {
 func (*ClusterMessage_Assignment) ProtoMessage() {}
 
 func (x *ClusterMessage_Assignment) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_leader_proto_msgTypes[24]
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2359,7 +2419,7 @@ type ClusterMessage_Snapshot struct {
 
 func (x *ClusterMessage_Snapshot) Reset() {
 	*x = ClusterMessage_Snapshot{}
-	mi := &file_atoms_splitter_private_leader_proto_msgTypes[25]
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2371,7 +2431,7 @@ func (x *ClusterMessage_Snapshot) String() string {
 func (*ClusterMessage_Snapshot) ProtoMessage() {}
 
 func (x *ClusterMessage_Snapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_leader_proto_msgTypes[25]
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2410,7 +2470,7 @@ type ClusterMessage_Update struct {
 
 func (x *ClusterMessage_Update) Reset() {
 	*x = ClusterMessage_Update{}
-	mi := &file_atoms_splitter_private_leader_proto_msgTypes[26]
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2422,7 +2482,7 @@ func (x *ClusterMessage_Update) String() string {
 func (*ClusterMessage_Update) ProtoMessage() {}
 
 func (x *ClusterMessage_Update) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_leader_proto_msgTypes[26]
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2454,7 +2514,7 @@ type ClusterMessage_Remove struct {
 
 func (x *ClusterMessage_Remove) Reset() {
 	*x = ClusterMessage_Remove{}
-	mi := &file_atoms_splitter_private_leader_proto_msgTypes[27]
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2466,7 +2526,7 @@ func (x *ClusterMessage_Remove) String() string {
 func (*ClusterMessage_Remove) ProtoMessage() {}
 
 func (x *ClusterMessage_Remove) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_leader_proto_msgTypes[27]
+	mi := &file_atoms_splitter_private_leader_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2493,7 +2553,7 @@ var File_atoms_splitter_private_leader_proto protoreflect.FileDescriptor
 
 const file_atoms_splitter_private_leader_proto_rawDesc = "" +
 	"\n" +
-	"#atoms/splitter/private/leader.proto\x12\x16atoms.splitter.private\x1a\x1aatoms/splitter/model.proto\x1a\"atoms/splitter/managementapi.proto\x1a&atoms/splitter/private/operation.proto\x1a&atoms/splitter/private/placement.proto\x1a\"atoms/splitter/private/state.proto\x1a0atoms/splitter/lib/service/session/session.proto\x1a2atoms/splitter/lib/service/location/location.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbd\x02\n" +
+	"#atoms/splitter/private/leader.proto\x12\x16atoms.splitter.private\x1a\x1aatoms/splitter/model.proto\x1a\"atoms/splitter/managementapi.proto\x1a!atoms/splitter/private/load.proto\x1a&atoms/splitter/private/operation.proto\x1a&atoms/splitter/private/placement.proto\x1a\"atoms/splitter/private/state.proto\x1a0atoms/splitter/lib/service/session/session.proto\x1a2atoms/splitter/lib/service/location/location.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbd\x02\n" +
 	"\rTenantRequest\x128\n" +
 	"\x04list\x18\x01 \x01(\v2\".atoms.splitter.ListTenantsRequestH\x00R\x04list\x124\n" +
 	"\x03new\x18\x02 \x01(\v2 .atoms.splitter.NewTenantRequestH\x00R\x03new\x127\n" +
@@ -2574,7 +2634,8 @@ const file_atoms_splitter_private_leader_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12>\n" +
 	"\aservice\x18\x02 \x01(\v2$.atoms.splitter.QualifiedServiceNameR\aservice\x120\n" +
 	"\x05lease\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x05lease\x126\n" +
-	"\bassigned\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\bassigned\"\xe6\b\n" +
+	"\bassigned\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\bassigned\"\x92\n" +
+	"\n" +
 	"\rWorkerMessage\x12L\n" +
 	"\bregister\x18\x01 \x01(\v2..atoms.splitter.private.WorkerMessage.RegisterH\x00R\bregister\x12R\n" +
 	"\n" +
@@ -2584,7 +2645,8 @@ const file_atoms_splitter_private_leader_proto_rawDesc = "" +
 	"\x06assign\x18\x05 \x01(\v2,.atoms.splitter.private.WorkerMessage.AssignH\x00R\x06assign\x12F\n" +
 	"\x06update\x18\b \x01(\v2,.atoms.splitter.private.WorkerMessage.UpdateH\x00R\x06update\x12F\n" +
 	"\x06revoke\x18\x06 \x01(\v2,.atoms.splitter.private.WorkerMessage.RevokeH\x00R\x06revoke\x12X\n" +
-	"\frelinquished\x18\a \x01(\v22.atoms.splitter.private.WorkerMessage.RelinquishedH\x00R\frelinquished\x1as\n" +
+	"\frelinquished\x18\a \x01(\v22.atoms.splitter.private.WorkerMessage.RelinquishedH\x00R\frelinquished\x12\\\n" +
+	"\x0eservice_status\x18\t \x01(\v23.atoms.splitter.private.WorkerMessage.ServiceStatusH\x00R\rserviceStatus\x1as\n" +
 	"\bRegister\x120\n" +
 	"\x06worker\x18\x01 \x01(\v2\x18.atoms.splitter.InstanceR\x06worker\x125\n" +
 	"\x06active\x18\x02 \x03(\v2\x1d.atoms.splitter.private.GrantR\x06active\x1a\f\n" +
@@ -2601,7 +2663,9 @@ const file_atoms_splitter_private_leader_proto_rawDesc = "" +
 	"\x06Revoke\x125\n" +
 	"\x06grants\x18\x01 \x03(\v2\x1d.atoms.splitter.private.GrantR\x06grants\x1aE\n" +
 	"\fRelinquished\x125\n" +
-	"\x06grants\x18\x01 \x03(\v2\x1d.atoms.splitter.private.GrantR\x06grantsB\x05\n" +
+	"\x06grants\x18\x01 \x03(\v2\x1d.atoms.splitter.private.GrantR\x06grants\x1aL\n" +
+	"\rServiceStatus\x12;\n" +
+	"\x04load\x18\x01 \x01(\v2'.atoms.splitter.private.ServiceLoadInfoR\x04loadB\x05\n" +
 	"\x03msg\"\xa7\x06\n" +
 	"\x0eClusterMessage\x12M\n" +
 	"\bsnapshot\x18\x01 \x01(\v2/.atoms.splitter.private.ClusterMessage.SnapshotH\x00R\bsnapshot\x12G\n" +
@@ -2646,129 +2710,131 @@ func file_atoms_splitter_private_leader_proto_rawDescGZIP() []byte {
 	return file_atoms_splitter_private_leader_proto_rawDescData
 }
 
-var file_atoms_splitter_private_leader_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_atoms_splitter_private_leader_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_atoms_splitter_private_leader_proto_goTypes = []any{
-	(*TenantRequest)(nil),              // 0: atoms.splitter.private.TenantRequest
-	(*TenantResponse)(nil),             // 1: atoms.splitter.private.TenantResponse
-	(*ServiceRequest)(nil),             // 2: atoms.splitter.private.ServiceRequest
-	(*ServiceResponse)(nil),            // 3: atoms.splitter.private.ServiceResponse
-	(*DomainRequest)(nil),              // 4: atoms.splitter.private.DomainRequest
-	(*DomainResponse)(nil),             // 5: atoms.splitter.private.DomainResponse
-	(*PlacementRequest)(nil),           // 6: atoms.splitter.private.PlacementRequest
-	(*PlacementResponse)(nil),          // 7: atoms.splitter.private.PlacementResponse
-	(*OperationRequest)(nil),           // 8: atoms.splitter.private.OperationRequest
-	(*OperationResponse)(nil),          // 9: atoms.splitter.private.OperationResponse
-	(*LeaderHandleRequest)(nil),        // 10: atoms.splitter.private.LeaderHandleRequest
-	(*LeaderHandleResponse)(nil),       // 11: atoms.splitter.private.LeaderHandleResponse
-	(*Grant)(nil),                      // 12: atoms.splitter.private.Grant
-	(*WorkerMessage)(nil),              // 13: atoms.splitter.private.WorkerMessage
-	(*ClusterMessage)(nil),             // 14: atoms.splitter.private.ClusterMessage
-	(*LeaderMessage)(nil),              // 15: atoms.splitter.private.LeaderMessage
-	(*JoinMessage)(nil),                // 16: atoms.splitter.private.JoinMessage
-	(*WorkerMessage_Register)(nil),     // 17: atoms.splitter.private.WorkerMessage.Register
-	(*WorkerMessage_Deregister)(nil),   // 18: atoms.splitter.private.WorkerMessage.Deregister
-	(*WorkerMessage_LeaseUpdate)(nil),  // 19: atoms.splitter.private.WorkerMessage.LeaseUpdate
-	(*WorkerMessage_Assign)(nil),       // 20: atoms.splitter.private.WorkerMessage.Assign
-	(*WorkerMessage_Update)(nil),       // 21: atoms.splitter.private.WorkerMessage.Update
-	(*WorkerMessage_Revoke)(nil),       // 22: atoms.splitter.private.WorkerMessage.Revoke
-	(*WorkerMessage_Relinquished)(nil), // 23: atoms.splitter.private.WorkerMessage.Relinquished
-	(*ClusterMessage_Assignment)(nil),  // 24: atoms.splitter.private.ClusterMessage.Assignment
-	(*ClusterMessage_Snapshot)(nil),    // 25: atoms.splitter.private.ClusterMessage.Snapshot
-	(*ClusterMessage_Update)(nil),      // 26: atoms.splitter.private.ClusterMessage.Update
-	(*ClusterMessage_Remove)(nil),      // 27: atoms.splitter.private.ClusterMessage.Remove
-	(*pb.ListTenantsRequest)(nil),      // 28: atoms.splitter.ListTenantsRequest
-	(*pb.NewTenantRequest)(nil),        // 29: atoms.splitter.NewTenantRequest
-	(*pb.InfoTenantRequest)(nil),       // 30: atoms.splitter.InfoTenantRequest
-	(*pb.UpdateTenantRequest)(nil),     // 31: atoms.splitter.UpdateTenantRequest
-	(*pb.DeleteTenantRequest)(nil),     // 32: atoms.splitter.DeleteTenantRequest
-	(*pb.ListTenantsResponse)(nil),     // 33: atoms.splitter.ListTenantsResponse
-	(*pb.NewTenantResponse)(nil),       // 34: atoms.splitter.NewTenantResponse
-	(*pb.InfoTenantResponse)(nil),      // 35: atoms.splitter.InfoTenantResponse
-	(*pb.UpdateTenantResponse)(nil),    // 36: atoms.splitter.UpdateTenantResponse
-	(*pb.DeleteTenantResponse)(nil),    // 37: atoms.splitter.DeleteTenantResponse
-	(*pb.ListServicesRequest)(nil),     // 38: atoms.splitter.ListServicesRequest
-	(*pb.NewServiceRequest)(nil),       // 39: atoms.splitter.NewServiceRequest
-	(*pb.InfoServiceRequest)(nil),      // 40: atoms.splitter.InfoServiceRequest
-	(*pb.UpdateServiceRequest)(nil),    // 41: atoms.splitter.UpdateServiceRequest
-	(*pb.DeleteServiceRequest)(nil),    // 42: atoms.splitter.DeleteServiceRequest
-	(*pb.ListServicesResponse)(nil),    // 43: atoms.splitter.ListServicesResponse
-	(*pb.NewServiceResponse)(nil),      // 44: atoms.splitter.NewServiceResponse
-	(*pb.InfoServiceResponse)(nil),     // 45: atoms.splitter.InfoServiceResponse
-	(*pb.UpdateServiceResponse)(nil),   // 46: atoms.splitter.UpdateServiceResponse
-	(*pb.DeleteServiceResponse)(nil),   // 47: atoms.splitter.DeleteServiceResponse
-	(*pb.ListDomainsRequest)(nil),      // 48: atoms.splitter.ListDomainsRequest
-	(*pb.NewDomainRequest)(nil),        // 49: atoms.splitter.NewDomainRequest
-	(*pb.UpdateDomainRequest)(nil),     // 50: atoms.splitter.UpdateDomainRequest
-	(*pb.DeleteDomainRequest)(nil),     // 51: atoms.splitter.DeleteDomainRequest
-	(*pb.ListDomainsResponse)(nil),     // 52: atoms.splitter.ListDomainsResponse
-	(*pb.NewDomainResponse)(nil),       // 53: atoms.splitter.NewDomainResponse
-	(*pb.UpdateDomainResponse)(nil),    // 54: atoms.splitter.UpdateDomainResponse
-	(*pb.DeleteDomainResponse)(nil),    // 55: atoms.splitter.DeleteDomainResponse
-	(*ListPlacementsRequest)(nil),      // 56: atoms.splitter.private.ListPlacementsRequest
-	(*NewPlacementRequest)(nil),        // 57: atoms.splitter.private.NewPlacementRequest
-	(*InfoPlacementRequest)(nil),       // 58: atoms.splitter.private.InfoPlacementRequest
-	(*UpdatePlacementRequest)(nil),     // 59: atoms.splitter.private.UpdatePlacementRequest
-	(*DeletePlacementRequest)(nil),     // 60: atoms.splitter.private.DeletePlacementRequest
-	(*ListPlacementsResponse)(nil),     // 61: atoms.splitter.private.ListPlacementsResponse
-	(*NewPlacementResponse)(nil),       // 62: atoms.splitter.private.NewPlacementResponse
-	(*InfoPlacementResponse)(nil),      // 63: atoms.splitter.private.InfoPlacementResponse
-	(*UpdatePlacementResponse)(nil),    // 64: atoms.splitter.private.UpdatePlacementResponse
-	(*DeletePlacementResponse)(nil),    // 65: atoms.splitter.private.DeletePlacementResponse
-	(*RestoreRequest)(nil),             // 66: atoms.splitter.private.RestoreRequest
-	(*SnapshotRequest)(nil),            // 67: atoms.splitter.private.SnapshotRequest
-	(*RestoreResponse)(nil),            // 68: atoms.splitter.private.RestoreResponse
-	(*SnapshotResponse)(nil),           // 69: atoms.splitter.private.SnapshotResponse
-	(*pb.QualifiedServiceName)(nil),    // 70: atoms.splitter.QualifiedServiceName
-	(*timestamppb.Timestamp)(nil),      // 71: google.protobuf.Timestamp
-	(*pb1.Message)(nil),                // 72: atoms.splitter.lib.service.service.Message
-	(*pb.Instance)(nil),                // 73: atoms.splitter.Instance
-	(*State)(nil),                      // 74: atoms.splitter.private.State
-	(*Update)(nil),                     // 75: atoms.splitter.private.Update
-	(*pb2.Instance)(nil),               // 76: atoms.splitter.lib.service.location.Instance
+	(*TenantRequest)(nil),               // 0: atoms.splitter.private.TenantRequest
+	(*TenantResponse)(nil),              // 1: atoms.splitter.private.TenantResponse
+	(*ServiceRequest)(nil),              // 2: atoms.splitter.private.ServiceRequest
+	(*ServiceResponse)(nil),             // 3: atoms.splitter.private.ServiceResponse
+	(*DomainRequest)(nil),               // 4: atoms.splitter.private.DomainRequest
+	(*DomainResponse)(nil),              // 5: atoms.splitter.private.DomainResponse
+	(*PlacementRequest)(nil),            // 6: atoms.splitter.private.PlacementRequest
+	(*PlacementResponse)(nil),           // 7: atoms.splitter.private.PlacementResponse
+	(*OperationRequest)(nil),            // 8: atoms.splitter.private.OperationRequest
+	(*OperationResponse)(nil),           // 9: atoms.splitter.private.OperationResponse
+	(*LeaderHandleRequest)(nil),         // 10: atoms.splitter.private.LeaderHandleRequest
+	(*LeaderHandleResponse)(nil),        // 11: atoms.splitter.private.LeaderHandleResponse
+	(*Grant)(nil),                       // 12: atoms.splitter.private.Grant
+	(*WorkerMessage)(nil),               // 13: atoms.splitter.private.WorkerMessage
+	(*ClusterMessage)(nil),              // 14: atoms.splitter.private.ClusterMessage
+	(*LeaderMessage)(nil),               // 15: atoms.splitter.private.LeaderMessage
+	(*JoinMessage)(nil),                 // 16: atoms.splitter.private.JoinMessage
+	(*WorkerMessage_Register)(nil),      // 17: atoms.splitter.private.WorkerMessage.Register
+	(*WorkerMessage_Deregister)(nil),    // 18: atoms.splitter.private.WorkerMessage.Deregister
+	(*WorkerMessage_LeaseUpdate)(nil),   // 19: atoms.splitter.private.WorkerMessage.LeaseUpdate
+	(*WorkerMessage_Assign)(nil),        // 20: atoms.splitter.private.WorkerMessage.Assign
+	(*WorkerMessage_Update)(nil),        // 21: atoms.splitter.private.WorkerMessage.Update
+	(*WorkerMessage_Revoke)(nil),        // 22: atoms.splitter.private.WorkerMessage.Revoke
+	(*WorkerMessage_Relinquished)(nil),  // 23: atoms.splitter.private.WorkerMessage.Relinquished
+	(*WorkerMessage_ServiceStatus)(nil), // 24: atoms.splitter.private.WorkerMessage.ServiceStatus
+	(*ClusterMessage_Assignment)(nil),   // 25: atoms.splitter.private.ClusterMessage.Assignment
+	(*ClusterMessage_Snapshot)(nil),     // 26: atoms.splitter.private.ClusterMessage.Snapshot
+	(*ClusterMessage_Update)(nil),       // 27: atoms.splitter.private.ClusterMessage.Update
+	(*ClusterMessage_Remove)(nil),       // 28: atoms.splitter.private.ClusterMessage.Remove
+	(*pb.ListTenantsRequest)(nil),       // 29: atoms.splitter.ListTenantsRequest
+	(*pb.NewTenantRequest)(nil),         // 30: atoms.splitter.NewTenantRequest
+	(*pb.InfoTenantRequest)(nil),        // 31: atoms.splitter.InfoTenantRequest
+	(*pb.UpdateTenantRequest)(nil),      // 32: atoms.splitter.UpdateTenantRequest
+	(*pb.DeleteTenantRequest)(nil),      // 33: atoms.splitter.DeleteTenantRequest
+	(*pb.ListTenantsResponse)(nil),      // 34: atoms.splitter.ListTenantsResponse
+	(*pb.NewTenantResponse)(nil),        // 35: atoms.splitter.NewTenantResponse
+	(*pb.InfoTenantResponse)(nil),       // 36: atoms.splitter.InfoTenantResponse
+	(*pb.UpdateTenantResponse)(nil),     // 37: atoms.splitter.UpdateTenantResponse
+	(*pb.DeleteTenantResponse)(nil),     // 38: atoms.splitter.DeleteTenantResponse
+	(*pb.ListServicesRequest)(nil),      // 39: atoms.splitter.ListServicesRequest
+	(*pb.NewServiceRequest)(nil),        // 40: atoms.splitter.NewServiceRequest
+	(*pb.InfoServiceRequest)(nil),       // 41: atoms.splitter.InfoServiceRequest
+	(*pb.UpdateServiceRequest)(nil),     // 42: atoms.splitter.UpdateServiceRequest
+	(*pb.DeleteServiceRequest)(nil),     // 43: atoms.splitter.DeleteServiceRequest
+	(*pb.ListServicesResponse)(nil),     // 44: atoms.splitter.ListServicesResponse
+	(*pb.NewServiceResponse)(nil),       // 45: atoms.splitter.NewServiceResponse
+	(*pb.InfoServiceResponse)(nil),      // 46: atoms.splitter.InfoServiceResponse
+	(*pb.UpdateServiceResponse)(nil),    // 47: atoms.splitter.UpdateServiceResponse
+	(*pb.DeleteServiceResponse)(nil),    // 48: atoms.splitter.DeleteServiceResponse
+	(*pb.ListDomainsRequest)(nil),       // 49: atoms.splitter.ListDomainsRequest
+	(*pb.NewDomainRequest)(nil),         // 50: atoms.splitter.NewDomainRequest
+	(*pb.UpdateDomainRequest)(nil),      // 51: atoms.splitter.UpdateDomainRequest
+	(*pb.DeleteDomainRequest)(nil),      // 52: atoms.splitter.DeleteDomainRequest
+	(*pb.ListDomainsResponse)(nil),      // 53: atoms.splitter.ListDomainsResponse
+	(*pb.NewDomainResponse)(nil),        // 54: atoms.splitter.NewDomainResponse
+	(*pb.UpdateDomainResponse)(nil),     // 55: atoms.splitter.UpdateDomainResponse
+	(*pb.DeleteDomainResponse)(nil),     // 56: atoms.splitter.DeleteDomainResponse
+	(*ListPlacementsRequest)(nil),       // 57: atoms.splitter.private.ListPlacementsRequest
+	(*NewPlacementRequest)(nil),         // 58: atoms.splitter.private.NewPlacementRequest
+	(*InfoPlacementRequest)(nil),        // 59: atoms.splitter.private.InfoPlacementRequest
+	(*UpdatePlacementRequest)(nil),      // 60: atoms.splitter.private.UpdatePlacementRequest
+	(*DeletePlacementRequest)(nil),      // 61: atoms.splitter.private.DeletePlacementRequest
+	(*ListPlacementsResponse)(nil),      // 62: atoms.splitter.private.ListPlacementsResponse
+	(*NewPlacementResponse)(nil),        // 63: atoms.splitter.private.NewPlacementResponse
+	(*InfoPlacementResponse)(nil),       // 64: atoms.splitter.private.InfoPlacementResponse
+	(*UpdatePlacementResponse)(nil),     // 65: atoms.splitter.private.UpdatePlacementResponse
+	(*DeletePlacementResponse)(nil),     // 66: atoms.splitter.private.DeletePlacementResponse
+	(*RestoreRequest)(nil),              // 67: atoms.splitter.private.RestoreRequest
+	(*SnapshotRequest)(nil),             // 68: atoms.splitter.private.SnapshotRequest
+	(*RestoreResponse)(nil),             // 69: atoms.splitter.private.RestoreResponse
+	(*SnapshotResponse)(nil),            // 70: atoms.splitter.private.SnapshotResponse
+	(*pb.QualifiedServiceName)(nil),     // 71: atoms.splitter.QualifiedServiceName
+	(*timestamppb.Timestamp)(nil),       // 72: google.protobuf.Timestamp
+	(*pb1.Message)(nil),                 // 73: atoms.splitter.lib.service.service.Message
+	(*pb.Instance)(nil),                 // 74: atoms.splitter.Instance
+	(*State)(nil),                       // 75: atoms.splitter.private.State
+	(*Update)(nil),                      // 76: atoms.splitter.private.Update
+	(*ServiceLoadInfo)(nil),             // 77: atoms.splitter.private.ServiceLoadInfo
+	(*pb2.Instance)(nil),                // 78: atoms.splitter.lib.service.location.Instance
 }
 var file_atoms_splitter_private_leader_proto_depIdxs = []int32{
-	28, // 0: atoms.splitter.private.TenantRequest.list:type_name -> atoms.splitter.ListTenantsRequest
-	29, // 1: atoms.splitter.private.TenantRequest.new:type_name -> atoms.splitter.NewTenantRequest
-	30, // 2: atoms.splitter.private.TenantRequest.info:type_name -> atoms.splitter.InfoTenantRequest
-	31, // 3: atoms.splitter.private.TenantRequest.update:type_name -> atoms.splitter.UpdateTenantRequest
-	32, // 4: atoms.splitter.private.TenantRequest.delete:type_name -> atoms.splitter.DeleteTenantRequest
-	33, // 5: atoms.splitter.private.TenantResponse.list:type_name -> atoms.splitter.ListTenantsResponse
-	34, // 6: atoms.splitter.private.TenantResponse.new:type_name -> atoms.splitter.NewTenantResponse
-	35, // 7: atoms.splitter.private.TenantResponse.info:type_name -> atoms.splitter.InfoTenantResponse
-	36, // 8: atoms.splitter.private.TenantResponse.update:type_name -> atoms.splitter.UpdateTenantResponse
-	37, // 9: atoms.splitter.private.TenantResponse.delete:type_name -> atoms.splitter.DeleteTenantResponse
-	38, // 10: atoms.splitter.private.ServiceRequest.list:type_name -> atoms.splitter.ListServicesRequest
-	39, // 11: atoms.splitter.private.ServiceRequest.new:type_name -> atoms.splitter.NewServiceRequest
-	40, // 12: atoms.splitter.private.ServiceRequest.info:type_name -> atoms.splitter.InfoServiceRequest
-	41, // 13: atoms.splitter.private.ServiceRequest.update:type_name -> atoms.splitter.UpdateServiceRequest
-	42, // 14: atoms.splitter.private.ServiceRequest.delete:type_name -> atoms.splitter.DeleteServiceRequest
-	43, // 15: atoms.splitter.private.ServiceResponse.list:type_name -> atoms.splitter.ListServicesResponse
-	44, // 16: atoms.splitter.private.ServiceResponse.new:type_name -> atoms.splitter.NewServiceResponse
-	45, // 17: atoms.splitter.private.ServiceResponse.info:type_name -> atoms.splitter.InfoServiceResponse
-	46, // 18: atoms.splitter.private.ServiceResponse.update:type_name -> atoms.splitter.UpdateServiceResponse
-	47, // 19: atoms.splitter.private.ServiceResponse.delete:type_name -> atoms.splitter.DeleteServiceResponse
-	48, // 20: atoms.splitter.private.DomainRequest.list:type_name -> atoms.splitter.ListDomainsRequest
-	49, // 21: atoms.splitter.private.DomainRequest.new:type_name -> atoms.splitter.NewDomainRequest
-	50, // 22: atoms.splitter.private.DomainRequest.update:type_name -> atoms.splitter.UpdateDomainRequest
-	51, // 23: atoms.splitter.private.DomainRequest.delete:type_name -> atoms.splitter.DeleteDomainRequest
-	52, // 24: atoms.splitter.private.DomainResponse.list:type_name -> atoms.splitter.ListDomainsResponse
-	53, // 25: atoms.splitter.private.DomainResponse.new:type_name -> atoms.splitter.NewDomainResponse
-	54, // 26: atoms.splitter.private.DomainResponse.update:type_name -> atoms.splitter.UpdateDomainResponse
-	55, // 27: atoms.splitter.private.DomainResponse.delete:type_name -> atoms.splitter.DeleteDomainResponse
-	56, // 28: atoms.splitter.private.PlacementRequest.list:type_name -> atoms.splitter.private.ListPlacementsRequest
-	57, // 29: atoms.splitter.private.PlacementRequest.new:type_name -> atoms.splitter.private.NewPlacementRequest
-	58, // 30: atoms.splitter.private.PlacementRequest.info:type_name -> atoms.splitter.private.InfoPlacementRequest
-	59, // 31: atoms.splitter.private.PlacementRequest.update:type_name -> atoms.splitter.private.UpdatePlacementRequest
-	60, // 32: atoms.splitter.private.PlacementRequest.delete:type_name -> atoms.splitter.private.DeletePlacementRequest
-	61, // 33: atoms.splitter.private.PlacementResponse.list:type_name -> atoms.splitter.private.ListPlacementsResponse
-	62, // 34: atoms.splitter.private.PlacementResponse.new:type_name -> atoms.splitter.private.NewPlacementResponse
-	63, // 35: atoms.splitter.private.PlacementResponse.info:type_name -> atoms.splitter.private.InfoPlacementResponse
-	64, // 36: atoms.splitter.private.PlacementResponse.update:type_name -> atoms.splitter.private.UpdatePlacementResponse
-	65, // 37: atoms.splitter.private.PlacementResponse.delete:type_name -> atoms.splitter.private.DeletePlacementResponse
-	66, // 38: atoms.splitter.private.OperationRequest.restore:type_name -> atoms.splitter.private.RestoreRequest
-	67, // 39: atoms.splitter.private.OperationRequest.snapshot:type_name -> atoms.splitter.private.SnapshotRequest
-	68, // 40: atoms.splitter.private.OperationResponse.restore:type_name -> atoms.splitter.private.RestoreResponse
-	69, // 41: atoms.splitter.private.OperationResponse.snapshot:type_name -> atoms.splitter.private.SnapshotResponse
+	29, // 0: atoms.splitter.private.TenantRequest.list:type_name -> atoms.splitter.ListTenantsRequest
+	30, // 1: atoms.splitter.private.TenantRequest.new:type_name -> atoms.splitter.NewTenantRequest
+	31, // 2: atoms.splitter.private.TenantRequest.info:type_name -> atoms.splitter.InfoTenantRequest
+	32, // 3: atoms.splitter.private.TenantRequest.update:type_name -> atoms.splitter.UpdateTenantRequest
+	33, // 4: atoms.splitter.private.TenantRequest.delete:type_name -> atoms.splitter.DeleteTenantRequest
+	34, // 5: atoms.splitter.private.TenantResponse.list:type_name -> atoms.splitter.ListTenantsResponse
+	35, // 6: atoms.splitter.private.TenantResponse.new:type_name -> atoms.splitter.NewTenantResponse
+	36, // 7: atoms.splitter.private.TenantResponse.info:type_name -> atoms.splitter.InfoTenantResponse
+	37, // 8: atoms.splitter.private.TenantResponse.update:type_name -> atoms.splitter.UpdateTenantResponse
+	38, // 9: atoms.splitter.private.TenantResponse.delete:type_name -> atoms.splitter.DeleteTenantResponse
+	39, // 10: atoms.splitter.private.ServiceRequest.list:type_name -> atoms.splitter.ListServicesRequest
+	40, // 11: atoms.splitter.private.ServiceRequest.new:type_name -> atoms.splitter.NewServiceRequest
+	41, // 12: atoms.splitter.private.ServiceRequest.info:type_name -> atoms.splitter.InfoServiceRequest
+	42, // 13: atoms.splitter.private.ServiceRequest.update:type_name -> atoms.splitter.UpdateServiceRequest
+	43, // 14: atoms.splitter.private.ServiceRequest.delete:type_name -> atoms.splitter.DeleteServiceRequest
+	44, // 15: atoms.splitter.private.ServiceResponse.list:type_name -> atoms.splitter.ListServicesResponse
+	45, // 16: atoms.splitter.private.ServiceResponse.new:type_name -> atoms.splitter.NewServiceResponse
+	46, // 17: atoms.splitter.private.ServiceResponse.info:type_name -> atoms.splitter.InfoServiceResponse
+	47, // 18: atoms.splitter.private.ServiceResponse.update:type_name -> atoms.splitter.UpdateServiceResponse
+	48, // 19: atoms.splitter.private.ServiceResponse.delete:type_name -> atoms.splitter.DeleteServiceResponse
+	49, // 20: atoms.splitter.private.DomainRequest.list:type_name -> atoms.splitter.ListDomainsRequest
+	50, // 21: atoms.splitter.private.DomainRequest.new:type_name -> atoms.splitter.NewDomainRequest
+	51, // 22: atoms.splitter.private.DomainRequest.update:type_name -> atoms.splitter.UpdateDomainRequest
+	52, // 23: atoms.splitter.private.DomainRequest.delete:type_name -> atoms.splitter.DeleteDomainRequest
+	53, // 24: atoms.splitter.private.DomainResponse.list:type_name -> atoms.splitter.ListDomainsResponse
+	54, // 25: atoms.splitter.private.DomainResponse.new:type_name -> atoms.splitter.NewDomainResponse
+	55, // 26: atoms.splitter.private.DomainResponse.update:type_name -> atoms.splitter.UpdateDomainResponse
+	56, // 27: atoms.splitter.private.DomainResponse.delete:type_name -> atoms.splitter.DeleteDomainResponse
+	57, // 28: atoms.splitter.private.PlacementRequest.list:type_name -> atoms.splitter.private.ListPlacementsRequest
+	58, // 29: atoms.splitter.private.PlacementRequest.new:type_name -> atoms.splitter.private.NewPlacementRequest
+	59, // 30: atoms.splitter.private.PlacementRequest.info:type_name -> atoms.splitter.private.InfoPlacementRequest
+	60, // 31: atoms.splitter.private.PlacementRequest.update:type_name -> atoms.splitter.private.UpdatePlacementRequest
+	61, // 32: atoms.splitter.private.PlacementRequest.delete:type_name -> atoms.splitter.private.DeletePlacementRequest
+	62, // 33: atoms.splitter.private.PlacementResponse.list:type_name -> atoms.splitter.private.ListPlacementsResponse
+	63, // 34: atoms.splitter.private.PlacementResponse.new:type_name -> atoms.splitter.private.NewPlacementResponse
+	64, // 35: atoms.splitter.private.PlacementResponse.info:type_name -> atoms.splitter.private.InfoPlacementResponse
+	65, // 36: atoms.splitter.private.PlacementResponse.update:type_name -> atoms.splitter.private.UpdatePlacementResponse
+	66, // 37: atoms.splitter.private.PlacementResponse.delete:type_name -> atoms.splitter.private.DeletePlacementResponse
+	67, // 38: atoms.splitter.private.OperationRequest.restore:type_name -> atoms.splitter.private.RestoreRequest
+	68, // 39: atoms.splitter.private.OperationRequest.snapshot:type_name -> atoms.splitter.private.SnapshotRequest
+	69, // 40: atoms.splitter.private.OperationResponse.restore:type_name -> atoms.splitter.private.RestoreResponse
+	70, // 41: atoms.splitter.private.OperationResponse.snapshot:type_name -> atoms.splitter.private.SnapshotResponse
 	0,  // 42: atoms.splitter.private.LeaderHandleRequest.tenant:type_name -> atoms.splitter.private.TenantRequest
 	2,  // 43: atoms.splitter.private.LeaderHandleRequest.service:type_name -> atoms.splitter.private.ServiceRequest
 	4,  // 44: atoms.splitter.private.LeaderHandleRequest.domain:type_name -> atoms.splitter.private.DomainRequest
@@ -2779,9 +2845,9 @@ var file_atoms_splitter_private_leader_proto_depIdxs = []int32{
 	5,  // 49: atoms.splitter.private.LeaderHandleResponse.domain:type_name -> atoms.splitter.private.DomainResponse
 	7,  // 50: atoms.splitter.private.LeaderHandleResponse.placement:type_name -> atoms.splitter.private.PlacementResponse
 	9,  // 51: atoms.splitter.private.LeaderHandleResponse.operation:type_name -> atoms.splitter.private.OperationResponse
-	70, // 52: atoms.splitter.private.Grant.service:type_name -> atoms.splitter.QualifiedServiceName
-	71, // 53: atoms.splitter.private.Grant.lease:type_name -> google.protobuf.Timestamp
-	71, // 54: atoms.splitter.private.Grant.assigned:type_name -> google.protobuf.Timestamp
+	71, // 52: atoms.splitter.private.Grant.service:type_name -> atoms.splitter.QualifiedServiceName
+	72, // 53: atoms.splitter.private.Grant.lease:type_name -> google.protobuf.Timestamp
+	72, // 54: atoms.splitter.private.Grant.assigned:type_name -> google.protobuf.Timestamp
 	17, // 55: atoms.splitter.private.WorkerMessage.register:type_name -> atoms.splitter.private.WorkerMessage.Register
 	18, // 56: atoms.splitter.private.WorkerMessage.deregister:type_name -> atoms.splitter.private.WorkerMessage.Deregister
 	19, // 57: atoms.splitter.private.WorkerMessage.lease:type_name -> atoms.splitter.private.WorkerMessage.LeaseUpdate
@@ -2789,38 +2855,40 @@ var file_atoms_splitter_private_leader_proto_depIdxs = []int32{
 	21, // 59: atoms.splitter.private.WorkerMessage.update:type_name -> atoms.splitter.private.WorkerMessage.Update
 	22, // 60: atoms.splitter.private.WorkerMessage.revoke:type_name -> atoms.splitter.private.WorkerMessage.Revoke
 	23, // 61: atoms.splitter.private.WorkerMessage.relinquished:type_name -> atoms.splitter.private.WorkerMessage.Relinquished
-	25, // 62: atoms.splitter.private.ClusterMessage.snapshot:type_name -> atoms.splitter.private.ClusterMessage.Snapshot
-	26, // 63: atoms.splitter.private.ClusterMessage.update:type_name -> atoms.splitter.private.ClusterMessage.Update
-	27, // 64: atoms.splitter.private.ClusterMessage.remove:type_name -> atoms.splitter.private.ClusterMessage.Remove
-	71, // 65: atoms.splitter.private.ClusterMessage.timestamp:type_name -> google.protobuf.Timestamp
-	13, // 66: atoms.splitter.private.LeaderMessage.worker:type_name -> atoms.splitter.private.WorkerMessage
-	14, // 67: atoms.splitter.private.LeaderMessage.cluster:type_name -> atoms.splitter.private.ClusterMessage
-	72, // 68: atoms.splitter.private.JoinMessage.session:type_name -> atoms.splitter.lib.service.service.Message
-	15, // 69: atoms.splitter.private.JoinMessage.leader:type_name -> atoms.splitter.private.LeaderMessage
-	73, // 70: atoms.splitter.private.WorkerMessage.Register.worker:type_name -> atoms.splitter.Instance
-	12, // 71: atoms.splitter.private.WorkerMessage.Register.active:type_name -> atoms.splitter.private.Grant
-	71, // 72: atoms.splitter.private.WorkerMessage.LeaseUpdate.ttl:type_name -> google.protobuf.Timestamp
-	12, // 73: atoms.splitter.private.WorkerMessage.Assign.grant:type_name -> atoms.splitter.private.Grant
-	74, // 74: atoms.splitter.private.WorkerMessage.Assign.state:type_name -> atoms.splitter.private.State
-	12, // 75: atoms.splitter.private.WorkerMessage.Update.grant:type_name -> atoms.splitter.private.Grant
-	75, // 76: atoms.splitter.private.WorkerMessage.Update.state:type_name -> atoms.splitter.private.Update
-	12, // 77: atoms.splitter.private.WorkerMessage.Revoke.grants:type_name -> atoms.splitter.private.Grant
-	12, // 78: atoms.splitter.private.WorkerMessage.Relinquished.grants:type_name -> atoms.splitter.private.Grant
-	73, // 79: atoms.splitter.private.ClusterMessage.Assignment.worker:type_name -> atoms.splitter.Instance
-	12, // 80: atoms.splitter.private.ClusterMessage.Assignment.grants:type_name -> atoms.splitter.private.Grant
-	24, // 81: atoms.splitter.private.ClusterMessage.Snapshot.assignments:type_name -> atoms.splitter.private.ClusterMessage.Assignment
-	76, // 82: atoms.splitter.private.ClusterMessage.Snapshot.origin:type_name -> atoms.splitter.lib.service.location.Instance
-	24, // 83: atoms.splitter.private.ClusterMessage.Update.assignments:type_name -> atoms.splitter.private.ClusterMessage.Assignment
-	70, // 84: atoms.splitter.private.ClusterMessage.Remove.services:type_name -> atoms.splitter.QualifiedServiceName
-	16, // 85: atoms.splitter.private.LeaderService.Join:input_type -> atoms.splitter.private.JoinMessage
-	10, // 86: atoms.splitter.private.LeaderService.Handle:input_type -> atoms.splitter.private.LeaderHandleRequest
-	16, // 87: atoms.splitter.private.LeaderService.Join:output_type -> atoms.splitter.private.JoinMessage
-	11, // 88: atoms.splitter.private.LeaderService.Handle:output_type -> atoms.splitter.private.LeaderHandleResponse
-	87, // [87:89] is the sub-list for method output_type
-	85, // [85:87] is the sub-list for method input_type
-	85, // [85:85] is the sub-list for extension type_name
-	85, // [85:85] is the sub-list for extension extendee
-	0,  // [0:85] is the sub-list for field type_name
+	24, // 62: atoms.splitter.private.WorkerMessage.service_status:type_name -> atoms.splitter.private.WorkerMessage.ServiceStatus
+	26, // 63: atoms.splitter.private.ClusterMessage.snapshot:type_name -> atoms.splitter.private.ClusterMessage.Snapshot
+	27, // 64: atoms.splitter.private.ClusterMessage.update:type_name -> atoms.splitter.private.ClusterMessage.Update
+	28, // 65: atoms.splitter.private.ClusterMessage.remove:type_name -> atoms.splitter.private.ClusterMessage.Remove
+	72, // 66: atoms.splitter.private.ClusterMessage.timestamp:type_name -> google.protobuf.Timestamp
+	13, // 67: atoms.splitter.private.LeaderMessage.worker:type_name -> atoms.splitter.private.WorkerMessage
+	14, // 68: atoms.splitter.private.LeaderMessage.cluster:type_name -> atoms.splitter.private.ClusterMessage
+	73, // 69: atoms.splitter.private.JoinMessage.session:type_name -> atoms.splitter.lib.service.service.Message
+	15, // 70: atoms.splitter.private.JoinMessage.leader:type_name -> atoms.splitter.private.LeaderMessage
+	74, // 71: atoms.splitter.private.WorkerMessage.Register.worker:type_name -> atoms.splitter.Instance
+	12, // 72: atoms.splitter.private.WorkerMessage.Register.active:type_name -> atoms.splitter.private.Grant
+	72, // 73: atoms.splitter.private.WorkerMessage.LeaseUpdate.ttl:type_name -> google.protobuf.Timestamp
+	12, // 74: atoms.splitter.private.WorkerMessage.Assign.grant:type_name -> atoms.splitter.private.Grant
+	75, // 75: atoms.splitter.private.WorkerMessage.Assign.state:type_name -> atoms.splitter.private.State
+	12, // 76: atoms.splitter.private.WorkerMessage.Update.grant:type_name -> atoms.splitter.private.Grant
+	76, // 77: atoms.splitter.private.WorkerMessage.Update.state:type_name -> atoms.splitter.private.Update
+	12, // 78: atoms.splitter.private.WorkerMessage.Revoke.grants:type_name -> atoms.splitter.private.Grant
+	12, // 79: atoms.splitter.private.WorkerMessage.Relinquished.grants:type_name -> atoms.splitter.private.Grant
+	77, // 80: atoms.splitter.private.WorkerMessage.ServiceStatus.load:type_name -> atoms.splitter.private.ServiceLoadInfo
+	74, // 81: atoms.splitter.private.ClusterMessage.Assignment.worker:type_name -> atoms.splitter.Instance
+	12, // 82: atoms.splitter.private.ClusterMessage.Assignment.grants:type_name -> atoms.splitter.private.Grant
+	25, // 83: atoms.splitter.private.ClusterMessage.Snapshot.assignments:type_name -> atoms.splitter.private.ClusterMessage.Assignment
+	78, // 84: atoms.splitter.private.ClusterMessage.Snapshot.origin:type_name -> atoms.splitter.lib.service.location.Instance
+	25, // 85: atoms.splitter.private.ClusterMessage.Update.assignments:type_name -> atoms.splitter.private.ClusterMessage.Assignment
+	71, // 86: atoms.splitter.private.ClusterMessage.Remove.services:type_name -> atoms.splitter.QualifiedServiceName
+	16, // 87: atoms.splitter.private.LeaderService.Join:input_type -> atoms.splitter.private.JoinMessage
+	10, // 88: atoms.splitter.private.LeaderService.Handle:input_type -> atoms.splitter.private.LeaderHandleRequest
+	16, // 89: atoms.splitter.private.LeaderService.Join:output_type -> atoms.splitter.private.JoinMessage
+	11, // 90: atoms.splitter.private.LeaderService.Handle:output_type -> atoms.splitter.private.LeaderHandleResponse
+	89, // [89:91] is the sub-list for method output_type
+	87, // [87:89] is the sub-list for method input_type
+	87, // [87:87] is the sub-list for extension type_name
+	87, // [87:87] is the sub-list for extension extendee
+	0,  // [0:87] is the sub-list for field type_name
 }
 
 func init() { file_atoms_splitter_private_leader_proto_init() }
@@ -2828,6 +2896,7 @@ func file_atoms_splitter_private_leader_proto_init() {
 	if File_atoms_splitter_private_leader_proto != nil {
 		return
 	}
+	file_atoms_splitter_private_load_proto_init()
 	file_atoms_splitter_private_operation_proto_init()
 	file_atoms_splitter_private_placement_proto_init()
 	file_atoms_splitter_private_state_proto_init()
@@ -2915,6 +2984,7 @@ func file_atoms_splitter_private_leader_proto_init() {
 		(*WorkerMessage_Update_)(nil),
 		(*WorkerMessage_Revoke_)(nil),
 		(*WorkerMessage_Relinquished_)(nil),
+		(*WorkerMessage_ServiceStatus_)(nil),
 	}
 	file_atoms_splitter_private_leader_proto_msgTypes[14].OneofWrappers = []any{
 		(*ClusterMessage_Snapshot_)(nil),
@@ -2935,7 +3005,7 @@ func file_atoms_splitter_private_leader_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_atoms_splitter_private_leader_proto_rawDesc), len(file_atoms_splitter_private_leader_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   28,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/core/load.go
+++ b/pkg/core/load.go
@@ -317,3 +317,29 @@ func (t ServiceLoadInfo) Domains() []DomainLoadInfo {
 func (t ServiceLoadInfo) String() string {
 	return protox.MarshalTextString(t.pb)
 }
+
+type ServiceStatusMessage struct {
+	pb *splitterprivatepb.WorkerMessage_ServiceStatus
+}
+
+func NewServiceStatusMessage(serviceLoad ServiceLoadInfo) ServiceStatusMessage {
+	return ServiceStatusMessage{pb: &splitterprivatepb.WorkerMessage_ServiceStatus{
+		Load: UnwrapServiceLoadInfo(serviceLoad),
+	}}
+}
+
+func WrapServiceStatusMessage(pb *splitterprivatepb.WorkerMessage_ServiceStatus) ServiceStatusMessage {
+	return ServiceStatusMessage{pb: pb}
+}
+
+func UnwrapServiceStatusMessage(m ServiceStatusMessage) *splitterprivatepb.WorkerMessage_ServiceStatus {
+	return m.pb
+}
+
+func (m ServiceStatusMessage) Load() ServiceLoadInfo {
+	return WrapServiceLoadInfo(m.pb.GetLoad())
+}
+
+func (m ServiceStatusMessage) String() string {
+	return protox.MarshalTextString(m.pb)
+}

--- a/pkg/model/service.go
+++ b/pkg/model/service.go
@@ -7,11 +7,11 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"go.atoms.co/splitter/lib/service/location"
 	"go.atoms.co/lib/encoding/protox"
 	"go.atoms.co/lib/mapx"
-	"go.atoms.co/slicex"
 	"go.atoms.co/lib/stringx"
+	"go.atoms.co/slicex"
+	"go.atoms.co/splitter/lib/service/location"
 	splitterpb "go.atoms.co/splitter/pb"
 )
 
@@ -172,6 +172,12 @@ func WithLocalityOverrides(overrides map[location.Region]location.Region) Servic
 	}
 }
 
+func WithTrackLoad(trackLoad bool) ServiceConfigOption {
+	return func(cfg *splitterpb.Service_Config) {
+		cfg.TrackLoad = trackLoad
+	}
+}
+
 // ServiceConfig holds service configuration.
 type ServiceConfig struct {
 	pb *splitterpb.Service_Config
@@ -224,6 +230,10 @@ func (c ServiceConfig) Overrides() map[location.Region]location.Region {
 	return mapx.MapNew(c.pb.GetOverrides(), func(t *splitterpb.Service_Config_LocalityOverride) (location.Region, location.Region) {
 		return location.Region(t.GetShardRegion()), location.Region(t.GetConsumerRegion())
 	})
+}
+
+func (c ServiceConfig) TrackLoad() bool {
+	return c.pb.GetTrackLoad()
 }
 
 func (c ServiceConfig) Equals(c1 ServiceConfig) bool {

--- a/pkg/model/sharding.go
+++ b/pkg/model/sharding.go
@@ -24,12 +24,6 @@ func WithShards(shards int) ShardingPolicyOption {
 	}
 }
 
-func WithTrackLoad(track bool) ShardingPolicyOption {
-	return func(policy *splitterpb.ShardingPolicy) {
-		policy.TrackLoad = track
-	}
-}
-
 type ShardingPolicyShard struct {
 	From   Key
 	To     Key

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,13 +10,15 @@ import (
 	"go.uber.org/multierr"
 	"google.golang.org/grpc"
 
-	"go.atoms.co/splitter/lib/service/location"
-	"go.atoms.co/splitter/lib/service/session"
-	"go.atoms.co/lib/log"
 	"go.atoms.co/lib/chanx"
 	"go.atoms.co/lib/contextx"
+	"go.atoms.co/lib/log"
 	"go.atoms.co/lib/net/grpcx"
 	"go.atoms.co/lib/statshandlerx"
+	"go.atoms.co/splitter/lib/service/location"
+	"go.atoms.co/splitter/lib/service/session"
+	splitterpb "go.atoms.co/splitter/pb"
+	splitterprivatepb "go.atoms.co/splitter/pb/private"
 	"go.atoms.co/splitter/pkg/cluster"
 	"go.atoms.co/splitter/pkg/core"
 	"go.atoms.co/splitter/pkg/model"
@@ -25,8 +27,6 @@ import (
 	"go.atoms.co/splitter/pkg/service/frontend"
 	"go.atoms.co/splitter/pkg/service/leader"
 	"go.atoms.co/splitter/pkg/service/worker"
-	splitterprivatepb "go.atoms.co/splitter/pb/private"
-	splitterpb "go.atoms.co/splitter/pb"
 )
 
 type options struct {
@@ -98,7 +98,7 @@ func New(ctx context.Context, loc location.Location, endpoint string, cluster cl
 		})
 	}
 
-	factoryFn := func(ctx context.Context, service model.QualifiedServiceName, state core.State, updates <-chan core.Update) coordinator.Coordinator {
+	factoryFn := func(ctx context.Context, service model.QualifiedServiceName, state core.State, updates <-chan core.Update) (coordinator.Coordinator, <-chan core.ServiceStatusMessage) {
 		var copts []coordinator.Option
 		if opt.fastActivation {
 			copts = append(copts, coordinator.WithFastActivation())

--- a/pkg/service/coordinator/coordinator.go
+++ b/pkg/service/coordinator/coordinator.go
@@ -143,6 +143,7 @@ type coordinator struct {
 	noLb      map[model.Shard]bool // shards excluded from load balancing
 	cluster   *model.ClusterMap
 	messages  chan *sessionx.Message[model.ConsumerMessage]
+	out       chan core.ServiceStatusMessage
 
 	trackers map[model.QualifiedDomainName]*domainLoadTracker
 
@@ -151,7 +152,7 @@ type coordinator struct {
 	drain, initialized iox.AsyncCloser
 }
 
-func New(ctx context.Context, loc location.Location, service model.QualifiedServiceName, state core.State, updates <-chan core.Update, opts ...Option) Coordinator {
+func New(ctx context.Context, loc location.Location, service model.QualifiedServiceName, state core.State, updates <-chan core.Update, opts ...Option) (Coordinator, <-chan core.ServiceStatusMessage) {
 	c := &coordinator{
 		AsyncCloser:  iox.WithQuit(ctx.Done(), iox.NewAsyncCloser()),
 		self:         location.NewNamedInstance("coordinator", loc),
@@ -161,6 +162,7 @@ func New(ctx context.Context, loc location.Location, service model.QualifiedServ
 		consumers:    map[model.InstanceID]*consumerSession{},
 		observers:    map[model.InstanceID]*observerSession{},
 		messages:     make(chan *sessionx.Message[model.ConsumerMessage], 1000),
+		out:          make(chan core.ServiceStatusMessage, 100),
 
 		trackers: map[model.QualifiedDomainName]*domainLoadTracker{},
 
@@ -174,7 +176,7 @@ func New(ctx context.Context, loc location.Location, service model.QualifiedServ
 
 	go c.init(core.NewServiceContext(context.Background(), service), state, updates)
 
-	return c
+	return c, c.out
 }
 
 func (c *coordinator) Initialized() iox.RAsyncCloser {
@@ -558,6 +560,7 @@ func (c *coordinator) init(ctx context.Context, state core.State, updates <-chan
 }
 
 func (c *coordinator) process(ctx context.Context, updates <-chan core.Update) {
+	defer c.Close()
 	defer c.resetMetrics(ctx)
 
 	ticker := time.NewTicker(10*time.Second + randx.Duration(time.Second))
@@ -659,6 +662,18 @@ steady:
 		case <-loadTicker.C:
 			now := time.Now()
 			c.removeTrackerIfDomainRemoved(ctx)
+
+			service, ok := c.cache.Service(c.name)
+			if !ok {
+				log.Errorf(ctx, "Internal: invalid state for coordinator, service not found %v/%v", c.name, c.self)
+				return
+			}
+
+			if !service.Info().Service().Config().TrackLoad() {
+				log.Infof(ctx, "Load tracking for service %v is not enabled, skipping.", c.name)
+				break
+			}
+
 			for _, t := range c.trackers {
 				t.rotateIfNeeded(now)
 			}
@@ -666,7 +681,17 @@ steady:
 			// (1) emit domain load and shard load metrics
 			c.emitLoadMetrics(ctx)
 
-			// (2) TODO: report load to leader to persist information
+			// (2) report load to leader to persist information
+			load := mapx.MapValues(c.trackers, func(v *domainLoadTracker) core.DomainLoadInfo {
+				return v.snapshot()
+			})
+			serviceLoad := core.NewServiceLoadInfo(c.name, load)
+			serviceStatus := core.NewServiceStatusMessage(serviceLoad)
+			select {
+			case c.out <- serviceStatus:
+			default:
+				log.Warnf(ctx, "Skipping status update from coordinator %v to leader: outbound buffer full", c.self)
+			}
 
 			// (3) Record action latency
 			c.recordActionLatency(ctx, "tick/load", now)
@@ -1024,8 +1049,14 @@ func (c *coordinator) handleStatus(ctx context.Context, status model.StatusMessa
 				continue
 			}
 
-			if !domain.Config().ShardingPolicy().TrackLoad() {
-				log.Infof(ctx, "Load tracking for domain %v is not enabled, skipping", shard.Domain)
+			service, ok := c.cache.Service(domain.Name().Service)
+			if !ok {
+				log.Infof(ctx, "Failed to find service %v", domain.Name().Service)
+				continue
+			}
+
+			if !service.Info().Service().Config().TrackLoad() {
+				log.Infof(ctx, "TrackLoad for service %v is not enabled, skipping", domain.Name().Service)
 				continue
 			}
 

--- a/pkg/service/coordinator/coordinator_test.go
+++ b/pkg/service/coordinator/coordinator_test.go
@@ -46,7 +46,7 @@ func TestCoordinator_SingleConsumer(t *testing.T) {
 		domain, err := model.NewDomain(domainName, model.Unit, time.Now())
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
 		in := make(chan model.ConsumerMessage, 1)
@@ -99,7 +99,7 @@ func TestCoordinator_TwoConsumers(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
 		in := make(chan model.ConsumerMessage, 1)
@@ -239,7 +239,7 @@ func TestCoordinator_TwoConsumers_IgnoreLoadBalanceUnitDomain2(t *testing.T) {
 
 		// (1) Setup 1 regional domain "domain1" and 2 unit "domain1" + "domain2". 1 shard each.
 
-		coord := setup(ctx, t, []model.Domain{domain, unit, unit2}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain, unit, unit2}, WithFastActivation())
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
 		in := make(chan model.ConsumerMessage, 1)
@@ -310,7 +310,7 @@ func TestCoordinator_CapacityLimitConsumer(t *testing.T) {
 		))
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
 		in := make(chan model.ConsumerMessage, 1)
@@ -375,7 +375,7 @@ func TestCoordinator_NamedKeyConsumers(t *testing.T) {
 		))
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		// Worker 1 joins for key "test"
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
@@ -459,7 +459,7 @@ func TestCoordinator_NamedKeyDisconnectDropsNamedShardPenalty(t *testing.T) {
 		domain, err := model.NewDomain(domainName, model.Regional, time.Now(), model.WithDomainConfig(model.NewDomainConfig(model.WithDomainShardingPolicy(model.NewShardingPolicy(4)), model.WithDomainRegions("centralus"), model.WithDomainNamedKeys(name))))
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 		c := coord.(*coordinator)
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
@@ -513,7 +513,7 @@ func TestCoordinator_RevokeGrant(t *testing.T) {
 			model.NewDomainConfig(model.WithDomainShardingPolicy(model.NewShardingPolicy(2)))))
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
 		in := make(chan model.ConsumerMessage, 1)
@@ -615,7 +615,7 @@ func TestCoordinator_RelinquishGrant(t *testing.T) {
 			model.NewDomainConfig(model.WithDomainShardingPolicy(model.NewShardingPolicy(2)))))
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
 		in := make(chan model.ConsumerMessage, 1)
@@ -663,7 +663,7 @@ func TestCoordinator_CustomShards(t *testing.T) {
 
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		consumer1 := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint1")
 		in1 := make(chan model.ConsumerMessage, 1)
@@ -731,7 +731,7 @@ func TestCoordinator_RegionSpecificShards(t *testing.T) {
 
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		expectedRegionResults := map[model.Region][]uuidx.Range{
 			"centralus": {
@@ -801,7 +801,7 @@ func TestObserverConnection(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
-		coord := setup(ctx, t, []model.Domain{}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{}, WithFastActivation())
 
 		observer := location.NewNamedInstance("observer-1", location.New("us-west-2", "fubar-xyz123"))
 		observerInstance := model.NewInstance(observer, "foo")
@@ -835,7 +835,7 @@ func TestObserverReceivesClusterUpdates(t *testing.T) {
 		domain, err := model.NewDomain(domainName, model.Unit, time.Now())
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		observer := location.NewInstance(location.New("us-west-2", "fubar-xyz123"))
 		observerInstance := model.NewInstance(observer, "foo")
@@ -880,7 +880,7 @@ func TestMultipleObservers(t *testing.T) {
 		domain, err := model.NewDomain(domainName, model.Unit, time.Now())
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
+		coord, _ := setup(ctx, t, []model.Domain{domain}, WithFastActivation())
 
 		observers := make([]struct {
 			location location.Instance
@@ -939,7 +939,7 @@ func TestCoordinator_ConsumerReconnectsWhileSuspended(t *testing.T) {
 		))
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain})
+		coord, _ := setup(ctx, t, []model.Domain{domain})
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint1")
 		in1 := make(chan model.ConsumerMessage, 1)
@@ -990,7 +990,7 @@ func TestCoordinator_ConsumerSuspendAndResume(t *testing.T) {
 		))
 		require.NoError(t, err)
 
-		coord := setup(ctx, t, []model.Domain{domain})
+		coord, _ := setup(ctx, t, []model.Domain{domain})
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
 		in := make(chan model.ConsumerMessage, 1)
@@ -1055,7 +1055,7 @@ func TestCoordinator_NoGrantsDeregisterRemovedImmediately(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := context.Background()
 
-		coord := setup(ctx, t, nil, WithFastActivation())
+		coord, _ := setup(ctx, t, nil, WithFastActivation())
 
 		// Consumer A  will deregister with zero grants.
 		a := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint1")
@@ -1096,37 +1096,23 @@ func TestCoordinator_ConsumerShardLoad(t *testing.T) {
 		ctx := context.Background()
 
 		// domain named domainName1 has load tracking enabled.
-		sp1 := model.NewShardingPolicy(1, model.WithTrackLoad(true))
+		sp1 := model.NewShardingPolicy(1)
 		opt1 := model.WithDomainConfig(model.NewDomainConfig(model.WithDomainShardingPolicy(sp1)))
-		tracked, err := model.NewDomain(domainName, model.Unit, time.Now(), opt1)
+		domain, err := model.NewDomain(domainName, model.Unit, time.Now(), opt1)
 		require.NoError(t, err)
 
-		// domain named domainName2 has load tracking disabled
-		sp2 := model.NewShardingPolicy(1, model.WithTrackLoad(false))
-		opt2 := model.WithDomainConfig(model.NewDomainConfig(model.WithDomainShardingPolicy(sp2)))
-		untracked, err := model.NewDomain(domainName2, model.Unit, time.Now(), opt2)
-		require.NoError(t, err)
-
-		coord := setup(ctx, t, []model.Domain{tracked, untracked}, WithFastActivation())
+		cfg := model.NewServiceConfig(model.WithTrackLoad(true))
+		coord, cOut := setupWithServiceConfig(ctx, t, []model.Domain{domain}, cfg, WithFastActivation())
 		c := coord.(*coordinator)
 
 		w := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
 		in, out := connectConsumer(ctx, t, coord, w)
 
-		// should assign two shards
+		// should assign one shard
 		assign := readFn(t, out, isAssign)
 		require.Len(t, assign.Grants(), 1)
-		trackedShard := assign.Grants()[0].Shard()
-		trackedGrantId := assign.Grants()[0].ID()
-
-		assign = readFn(t, out, isAssign)
-		require.Len(t, assign.Grants(), 1)
-		untrackedShard := assign.Grants()[0].Shard()
-		untrackedGrantId := assign.Grants()[0].ID()
-		if trackedShard.Domain == domainName2 {
-			trackedShard, untrackedShard = untrackedShard, trackedShard
-			trackedGrantId, untrackedGrantId = untrackedGrantId, trackedGrantId
-		}
+		shard := assign.Grants()[0].Shard()
+		grantId := assign.Grants()[0].ID()
 
 		wg := sync.WaitGroup{}
 		wg.Add(1)
@@ -1141,18 +1127,11 @@ func TestCoordinator_ConsumerShardLoad(t *testing.T) {
 			wg.Wait()
 		}()
 
-		// TrackLoad is not enabled
-		msg := []model.ShardLoad{model.NewShardLoad(untrackedGrantId, model.Load(10))}
-		in <- model.NewShardLoadMessage(msg)
-		synctest.Wait()
-		require.NotContains(t, c.trackers, domainName2)
-
-		// TrackLoad is enabled
 		expected := model.Load(150)
 		size := 300
-		msg = make([]model.ShardLoad, size+1)
+		msg := make([]model.ShardLoad, size+1)
 		for i := 0; i <= size; i++ {
-			msg[i] = model.NewShardLoad(trackedGrantId, model.Load(i))
+			msg[i] = model.NewShardLoad(grantId, model.Load(i))
 		}
 		in <- model.NewShardLoadMessage(msg)
 		synctest.Wait()
@@ -1162,14 +1141,19 @@ func TestCoordinator_ConsumerShardLoad(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, expected, dl)
 
-		// update age of trackers to simulate time advancing.
-		updateAge(c.trackers, time.Now().Add(-(defaultRotationInterval + time.Millisecond)))
+		// update createdAt for trackers to simulate time advancing.
+		updateCreatedAt(c.trackers, time.Now().Add(-(defaultRotationInterval + time.Millisecond)))
 		time.Sleep(loadTickerInterval + 10*time.Second)
 		synctest.Wait()
 
+		// coordinator should send ServiceStatusMessage to its out chan
+		statusMsg := assertx.Element(t, cOut)
+		require.Equal(t, c.name.String(), statusMsg.Load().Service().String())
+
+		// tracker should be empty after rotation
 		dl, ok = c.trackers[domainName].domainLoad()
 		require.False(t, ok, "empty tracker should not have domain load")
-		sps := core.NewShard(trackedShard.From, trackedShard.To, trackedShard.Region)
+		sps := core.NewShard(shard.From, shard.To, shard.Region)
 		sl := c.trackers[domainName].shardScoreOrDefault(sps)
 		require.Equal(t, score(50.0), sl)
 	})
@@ -1178,7 +1162,7 @@ func TestCoordinator_ConsumerShardLoad(t *testing.T) {
 // updateCreatedAt updates the createdAt of domainLoadTrackers to simulate time advancing and avoid a long sleep (24 hours).
 // With synctest, time.Sleep triggers all tickers to fire within the synctest bubble;
 // long sleeps slow the test.
-func updateAge(trackers map[model.QualifiedDomainName]*domainLoadTracker, createdAt time.Time) {
+func updateCreatedAt(trackers map[model.QualifiedDomainName]*domainLoadTracker, createdAt time.Time) {
 	for _, tracker := range trackers {
 		tracker.tracker.createdAt = createdAt
 	}
@@ -1196,7 +1180,13 @@ func connectConsumer(ctx context.Context, t *testing.T, coord Coordinator, w mod
 	return in, out
 }
 
-func setup(ctx context.Context, t *testing.T, domains []model.Domain, opts ...Option) Coordinator {
+func setup(ctx context.Context, t *testing.T, domains []model.Domain, opts ...Option) (Coordinator, <-chan core.ServiceStatusMessage) {
+	t.Helper()
+
+	return setupWithServiceConfig(ctx, t, domains, model.NewServiceConfig(), opts...)
+}
+
+func setupWithServiceConfig(ctx context.Context, t *testing.T, domains []model.Domain, cfg model.ServiceConfig, opts ...Option) (Coordinator, <-chan core.ServiceStatusMessage) {
 	t.Helper()
 
 	loc := location.New("centralus", "splitter-0")
@@ -1204,7 +1194,7 @@ func setup(ctx context.Context, t *testing.T, domains []model.Domain, opts ...Op
 	tenant, err := model.NewTenant(tenant1, time.Now())
 	require.NoError(t, err)
 
-	service, err := model.NewService(serviceName, time.Now())
+	service, err := model.NewService(serviceName, time.Now(), model.WithServiceConfig(cfg))
 	require.NoError(t, err)
 
 	state := core.NewState(
@@ -1215,10 +1205,10 @@ func setup(ctx context.Context, t *testing.T, domains []model.Domain, opts ...Op
 
 	updates := make(chan core.Update)
 
-	c := New(ctx, loc, serviceName, state, updates, opts...)
+	c, out := New(ctx, loc, serviceName, state, updates, opts...)
 	<-c.Initialized().Closed()
 
-	return c
+	return c, out
 }
 
 func isAssign(msg model.ConsumerMessage) (model.AssignMessage, bool) {

--- a/pkg/service/leader/leader.go
+++ b/pkg/service/leader/leader.go
@@ -6,24 +6,24 @@ import (
 	"sync"
 	"time"
 
-	"go.atoms.co/splitter/lib/service/location"
-	"go.atoms.co/splitter/lib/service/session"
-	"go.atoms.co/lib/log"
-	"go.atoms.co/lib/metrics"
+	"go.atoms.co/iox"
 	"go.atoms.co/lib/chanx"
 	"go.atoms.co/lib/contextx"
-	"go.atoms.co/iox"
+	"go.atoms.co/lib/log"
 	"go.atoms.co/lib/mapx"
+	"go.atoms.co/lib/metrics"
 	"go.atoms.co/lib/randx"
-	"go.atoms.co/slicex"
 	"go.atoms.co/lib/syncx"
+	"go.atoms.co/slicex"
+	"go.atoms.co/splitter/lib/service/location"
+	"go.atoms.co/splitter/lib/service/session"
+	splitterpb "go.atoms.co/splitter/pb"
+	splitterprivatepb "go.atoms.co/splitter/pb/private"
 	"go.atoms.co/splitter/pkg/allocation"
 	"go.atoms.co/splitter/pkg/core"
 	"go.atoms.co/splitter/pkg/model"
 	"go.atoms.co/splitter/pkg/storage"
 	"go.atoms.co/splitter/pkg/util/sessionx"
-	splitterprivatepb "go.atoms.co/splitter/pb/private"
-	splitterpb "go.atoms.co/splitter/pb"
 )
 
 const (
@@ -364,6 +364,10 @@ func (l *leader) handleMessage(ctx context.Context, w *workerSession, m Message)
 	case msg.IsRelinquished():
 		relinquished, _ := msg.Relinquished()
 		l.handleRelinquished(ctx, w, relinquished)
+
+	case msg.IsServiceStatus():
+		// TODO: handleServiceStatus
+		log.Debugf(ctx, "Received service status message: %v", msg)
 
 	default:
 		log.Errorf(ctx, "Internal: unexpected worker message: %v", msg)

--- a/pkg/service/leader/messages.go
+++ b/pkg/service/leader/messages.go
@@ -5,14 +5,14 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"go.atoms.co/splitter/lib/service/location"
-	"go.atoms.co/splitter/lib/service/session"
 	"go.atoms.co/lib/encoding/protox"
 	"go.atoms.co/slicex"
+	"go.atoms.co/splitter/lib/service/location"
+	"go.atoms.co/splitter/lib/service/session"
+	splitterpb "go.atoms.co/splitter/pb"
+	splitterprivatepb "go.atoms.co/splitter/pb/private"
 	"go.atoms.co/splitter/pkg/core"
 	"go.atoms.co/splitter/pkg/model"
-	splitterprivatepb "go.atoms.co/splitter/pb/private"
-	splitterpb "go.atoms.co/splitter/pb"
 )
 
 type JoinMessage struct {
@@ -136,6 +136,14 @@ func NewRelinquished(grants ...core.Grant) Message {
 			Relinquished: &splitterprivatepb.WorkerMessage_Relinquished{
 				Grants: slicex.Map(grants, core.UnwrapGrant),
 			},
+		},
+	}})
+}
+
+func NewServiceStatus(serviceStatus core.ServiceStatusMessage) Message {
+	return NewWorkerMessage(WorkerMessage{pb: &splitterprivatepb.WorkerMessage{
+		Msg: &splitterprivatepb.WorkerMessage_ServiceStatus_{
+			ServiceStatus: core.UnwrapServiceStatusMessage(serviceStatus),
 		},
 	}})
 }
@@ -320,6 +328,17 @@ func (m WorkerMessage) Relinquished() (RelinquishedMessage, bool) {
 		return RelinquishedMessage{}, false
 	}
 	return RelinquishedMessage{pb: m.pb.GetRelinquished()}, true
+}
+
+func (m WorkerMessage) IsServiceStatus() bool {
+	return m.pb.GetServiceStatus() != nil
+}
+
+func (m WorkerMessage) ServiceStatus() (core.ServiceStatusMessage, bool) {
+	if !m.IsServiceStatus() {
+		return core.ServiceStatusMessage{}, false
+	}
+	return core.WrapServiceStatusMessage(m.pb.GetServiceStatus()), true
 }
 
 func (m WorkerMessage) String() string {

--- a/pkg/service/worker/worker.go
+++ b/pkg/service/worker/worker.go
@@ -6,24 +6,24 @@ import (
 	"sync"
 	"time"
 
-	"go.atoms.co/splitter/lib/service/location"
-	"go.atoms.co/splitter/lib/service/session"
-	"go.atoms.co/lib/log"
-	"go.atoms.co/lib/metrics"
-	"go.atoms.co/lib/timex"
+	"go.atoms.co/iox"
 	"go.atoms.co/lib/chanx"
 	"go.atoms.co/lib/contextx"
-	"go.atoms.co/lib/net/grpcx"
-	"go.atoms.co/iox"
+	"go.atoms.co/lib/log"
 	"go.atoms.co/lib/mapx"
+	"go.atoms.co/lib/metrics"
+	"go.atoms.co/lib/net/grpcx"
 	"go.atoms.co/lib/randx"
-	"go.atoms.co/slicex"
 	"go.atoms.co/lib/syncx"
+	"go.atoms.co/lib/timex"
+	"go.atoms.co/slicex"
+	"go.atoms.co/splitter/lib/service/location"
+	"go.atoms.co/splitter/lib/service/session"
+	splitterprivatepb "go.atoms.co/splitter/pb/private"
 	"go.atoms.co/splitter/pkg/core"
 	"go.atoms.co/splitter/pkg/model"
 	"go.atoms.co/splitter/pkg/service/coordinator"
 	"go.atoms.co/splitter/pkg/service/leader"
-	splitterprivatepb "go.atoms.co/splitter/pb/private"
 )
 
 const (
@@ -37,7 +37,7 @@ var (
 
 type JoinFn func(ctx context.Context, self location.Instance, handler grpcx.Handler[leader.Message, leader.Message]) error
 
-type CoordinatorFactory func(ctx context.Context, service model.QualifiedServiceName, state core.State, updates <-chan core.Update) coordinator.Coordinator
+type CoordinatorFactory func(ctx context.Context, service model.QualifiedServiceName, state core.State, updates <-chan core.Update) (coordinator.Coordinator, <-chan core.ServiceStatusMessage)
 
 type joinStatus struct {
 	connected time.Time
@@ -386,7 +386,7 @@ func (w *worker) handleWorkerMessage(ctx context.Context, msg leader.WorkerMessa
 		}
 
 		updates := make(chan core.Update, coordinatorStateBufferLen)
-		c := w.factory(ctx, grant.Service(), state, updates)
+		c, cOut := w.factory(ctx, grant.Service(), state, updates)
 
 		w.grants[grant.ID()] = &Grant{
 			Grant:       grant,
@@ -403,6 +403,26 @@ func (w *worker) handleWorkerMessage(ctx context.Context, msg leader.WorkerMessa
 			syncx.Txn0(ctx, w.txn, func() {
 				w.removeGrant(ctx, grant.ID())
 			})
+		}()
+
+		go func() {
+			for {
+				select {
+				case msg2, ok := <-cOut:
+					if !ok {
+						return
+					}
+
+					// w.out is closed and recreated when losing connection to leader.
+					// Putting below logic into transactional context to avoid race condition.
+					syncx.Txn0(ctx, w.txn, func() {
+						w.mustSend(ctx, leader.NewServiceStatus(msg2))
+					})
+
+				case <-c.Closed():
+					return
+				}
+			}
 		}()
 
 		log.Infof(ctx, "Created coordinator %v for grant %v", c, grant)

--- a/pkg/service/worker/worker_test.go
+++ b/pkg/service/worker/worker_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.atoms.co/splitter/lib/service/location"
-	"go.atoms.co/splitter/lib/service/session"
-	"go.atoms.co/lib/testing/assertx"
+	"go.atoms.co/iox"
 	"go.atoms.co/lib/chanx"
 	"go.atoms.co/lib/net/grpcx"
-	"go.atoms.co/iox"
+	"go.atoms.co/lib/testing/assertx"
+	"go.atoms.co/splitter/lib/service/location"
+	"go.atoms.co/splitter/lib/service/session"
+	splitterprivatepb "go.atoms.co/splitter/pb/private"
 	"go.atoms.co/splitter/pkg/core"
 	"go.atoms.co/splitter/pkg/model"
 	"go.atoms.co/splitter/pkg/service/coordinator"
 	"go.atoms.co/splitter/pkg/service/leader"
 	"go.atoms.co/splitter/pkg/service/worker"
-	splitterprivatepb "go.atoms.co/splitter/pb/private"
 )
 
 var (
@@ -115,6 +115,43 @@ func TestWorker(t *testing.T) {
 			assert.Error(t, err)
 		})
 	})
+
+	// (4) Coordinator status forwarded to leader
+	t.Run("status/report", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			d := setupWorkerTestDeps(t)
+			defer d.close()
+
+			grant := core.NewGrant("grant1", service1, time.Now().Add(time.Minute), time.Now())
+			d.leaderConn.Out <- leader.NewAssign(grant, core.State{})
+			c := assertx.Element(t, d.coordinatorChan)
+
+			p2quantileSnapshot := core.NewP2QuantileSnapshot(
+				0.5,
+				[]float64{10, 10, 10, 10, 10},
+				[]uint64{1, 2, 3, 4, 10},
+				[]float64{1, 2, 3, 4, 10},
+			)
+
+			domainName := model.DomainName("domain1")
+			trackers := core.NewDomainTrackerSnapshot(time.Now(), p2quantileSnapshot, nil)
+			domainLoad := []core.DomainLoadInfo{core.NewDomainLoadInfo(domainName, trackers, nil)}
+			serviceLoad := core.NewServiceLoadInfo(service1, domainLoad)
+			serviceStatus := core.NewServiceStatusMessage(serviceLoad)
+			c.out <- serviceStatus
+			synctest.Wait()
+
+			msg := assertx.Element(t, d.leaderConn.In)
+			wMsg, ok := msg.WorkerMessage()
+			require.True(t, ok)
+			require.True(t, wMsg.IsServiceStatus())
+
+			reported, ok := wMsg.ServiceStatus()
+			require.True(t, ok)
+			assert.Equal(t, service1.Tenant, reported.Load().Service().Tenant)
+			assert.Equal(t, service1, reported.Load().Service())
+		})
+	})
 }
 
 type fakeCoordinator struct {
@@ -122,6 +159,7 @@ type fakeCoordinator struct {
 	t           *testing.T
 	service     model.QualifiedServiceName
 	updates     <-chan core.Update
+	out         chan<- core.ServiceStatusMessage
 	initialized iox.RAsyncCloser
 }
 
@@ -137,15 +175,17 @@ func (f *fakeCoordinator) Handle(ctx context.Context, request coordinator.Handle
 	return nil, nil
 }
 
-func newFakeCoordinator(service model.QualifiedServiceName, updates <-chan core.Update) *fakeCoordinator {
+func newFakeCoordinator(service model.QualifiedServiceName, updates <-chan core.Update) (*fakeCoordinator, <-chan core.ServiceStatusMessage) {
 	i := iox.NewAsyncCloser()
 	i.Close()
+	out := make(chan core.ServiceStatusMessage, 100)
 	return &fakeCoordinator{
 		AsyncCloser: iox.NewAsyncCloser(),
 		initialized: i,
 		service:     service,
 		updates:     updates,
-	}
+		out:         out,
+	}, out
 }
 
 func (f *fakeCoordinator) Connect(ctx context.Context, sid session.ID, consumer location.Instance, in <-chan model.ConsumerMessage) (<-chan model.ConsumerMessage, error) {
@@ -216,11 +256,11 @@ func setupWorkerTestDeps(t *testing.T) *workerTestDeps {
 		return d.leaderConn.connect(ctx, handler)
 	}
 
-	coordFactory := func(ctx context.Context, service model.QualifiedServiceName, state core.State, updates <-chan core.Update) coordinator.Coordinator {
-		c := newFakeCoordinator(service, updates)
+	coordFactory := func(ctx context.Context, service model.QualifiedServiceName, state core.State, updates <-chan core.Update) (coordinator.Coordinator, <-chan core.ServiceStatusMessage) {
+		c, out := newFakeCoordinator(service, updates)
 		d.coordinators = append(d.coordinators, c)
 		d.coordinatorChan <- c
-		return c
+		return c, out
 	}
 
 	d.worker, _ = worker.New(location.New("centralus", "pod1"), "endpoint", joinFn, coordFactory)

--- a/proto/atoms/splitter/management.proto
+++ b/proto/atoms/splitter/management.proto
@@ -51,6 +51,9 @@ message Service {
 
     // region preferences for coordinator. Overrides `region` config if provided. Optional.
     repeated string regions = 4;
+    // Enables load tracking/reporting for the service
+    bool track_load = 5;
+
   }
   Config config = 2;
 
@@ -143,5 +146,6 @@ message ShardingPolicy {
   // final shard count can exceed or be less than target shard count.
   repeated Shard custom_shards = 2;
   // Enables load tracking/reporting for this sharding policy so consumers can report load.
+  // TODO: remove, use track_load check in Service.Config.
   bool track_load = 3;
 }

--- a/proto/atoms/splitter/private/leader.proto
+++ b/proto/atoms/splitter/private/leader.proto
@@ -4,6 +4,7 @@ package atoms.splitter.private;
 
 import "atoms/splitter/model.proto";
 import "atoms/splitter/managementapi.proto";
+import "atoms/splitter/private/load.proto";
 import "atoms/splitter/private/operation.proto";
 import "atoms/splitter/private/placement.proto";
 import "atoms/splitter/private/state.proto";
@@ -189,6 +190,11 @@ message WorkerMessage {
     repeated Grant grants = 1;
   }
 
+  // ServiceStatus represents status of a service.
+  message ServiceStatus {
+    ServiceLoadInfo load = 1;
+  }
+
   oneof msg {
     Register register = 1;
     Deregister deregister = 2;
@@ -197,6 +203,7 @@ message WorkerMessage {
     Update update = 8;
     Revoke revoke = 6;
     Relinquished relinquished = 7;
+    ServiceStatus service_status = 9;
   }
 }
 


### PR DESCRIPTION
This change:

- Add `ServiceStatusMessage` to WorkerMessage.
- Updates CoordinatorFactory by adding an out chan.
- Updates worker to forward `ServiceStatusMessage`  to the Leader.