### PR TITLE
Remove track_load from domain

### DIFF
--- a/pb/management.pb.go
+++ b/pb/management.pb.go
@@ -467,7 +467,6 @@ type ShardingPolicy struct {
 	state         protoimpl.MessageState  `protogen:"open.v1"`
 	Shards        int64                   `protobuf:"varint,1,opt,name=shards,proto3" json:"shards,omitempty"`
 	CustomShards  []*ShardingPolicy_Shard `protobuf:"bytes,2,rep,name=custom_shards,json=customShards,proto3" json:"custom_shards,omitempty"`
-	TrackLoad     bool                    `protobuf:"varint,3,opt,name=track_load,json=trackLoad,proto3" json:"track_load,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -514,13 +513,6 @@ func (x *ShardingPolicy) GetCustomShards() []*ShardingPolicy_Shard {
 		return x.CustomShards
 	}
 	return nil
-}
-
-func (x *ShardingPolicy) GetTrackLoad() bool {
-	if x != nil {
-		return x.TrackLoad
-	}
-	return false
 }
 
 type Tenant_Config struct {
@@ -1052,12 +1044,10 @@ const file_atoms_splitter_management_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\n" +
 	"\n" +
 	"\x06ACTIVE\x10\x01\x12\r\n" +
-	"\tSUSPENDED\x10\x02\"\xd7\x01\n" +
+	"\tSUSPENDED\x10\x02\"\xb8\x01\n" +
 	"\x0eShardingPolicy\x12\x16\n" +
 	"\x06shards\x18\x01 \x01(\x03R\x06shards\x12I\n" +
-	"\rcustom_shards\x18\x02 \x03(\v2$.atoms.splitter.ShardingPolicy.ShardR\fcustomShards\x12\x1d\n" +
-	"\n" +
-	"track_load\x18\x03 \x01(\bR\ttrackLoad\x1aC\n" +
+	"\rcustom_shards\x18\x02 \x03(\v2$.atoms.splitter.ShardingPolicy.ShardR\fcustomShards\x1aC\n" +
 	"\x05Shard\x12\x12\n" +
 	"\x04from\x18\x01 \x01(\tR\x04from\x12\x0e\n" +
 	"\x02to\x18\x02 \x01(\tR\x02to\x12\x16\n" +

--- a/pkg/model/sharding.go
+++ b/pkg/model/sharding.go
@@ -156,9 +156,6 @@ func (s ShardingPolicy) ShardingPolicyShards() ([]ShardingPolicyShard, error) {
 
 	return result, nil
 }
-func (s ShardingPolicy) TrackLoad() bool {
-	return s.pb.GetTrackLoad()
-}
 
 // ShardKV is a key-value with a shard.
 type ShardKV[K comparable, V any] struct {

--- a/proto/atoms/splitter/management.proto
+++ b/proto/atoms/splitter/management.proto
@@ -145,7 +145,4 @@ message ShardingPolicy {
   // Custom shards should be non over-lapping and defining custom shards changes the number of shards,
   // final shard count can exceed or be less than target shard count.
   repeated Shard custom_shards = 2;
-  // Enables load tracking/reporting for this sharding policy so consumers can report load.
-  // TODO: remove, use track_load check in Service.Config.
-  bool track_load = 3;
 }


### PR DESCRIPTION
This change removes `track_load` from domain, the `track_load` is moved to service config in previous PR.