### PR TITLE
Store service status in leader

### DIFF
--- a/pb/private/state.pb.go
+++ b/pb/private/state.pb.go
@@ -27,6 +27,7 @@ type State struct {
 	Tenant        *pb.TenantInfo           `protobuf:"bytes,1,opt,name=tenant,proto3" json:"tenant,omitempty"`
 	Services      []*pb.ServiceInfoEx      `protobuf:"bytes,2,rep,name=services,proto3" json:"services,omitempty"`
 	Placements    []*InternalPlacementInfo `protobuf:"bytes,3,rep,name=placements,proto3" json:"placements,omitempty"`
+	Statuses      []*ServiceStatus         `protobuf:"bytes,4,rep,name=statuses,proto3" json:"statuses,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -78,6 +79,13 @@ func (x *State) GetServices() []*pb.ServiceInfoEx {
 func (x *State) GetPlacements() []*InternalPlacementInfo {
 	if x != nil {
 		return x.Placements
+	}
+	return nil
+}
+
+func (x *State) GetStatuses() []*ServiceStatus {
+	if x != nil {
+		return x.Statuses
 	}
 	return nil
 }
@@ -142,19 +150,64 @@ func (x *ServiceUpdate) GetRemoved() []*pb.QualifiedDomainName {
 	return nil
 }
 
+type ServiceStatus struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Load          *ServiceLoadInfo       `protobuf:"bytes,1,opt,name=load,proto3" json:"load,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ServiceStatus) Reset() {
+	*x = ServiceStatus{}
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ServiceStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ServiceStatus) ProtoMessage() {}
+
+func (x *ServiceStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ServiceStatus.ProtoReflect.Descriptor instead.
+func (*ServiceStatus) Descriptor() ([]byte, []int) {
+	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ServiceStatus) GetLoad() *ServiceLoadInfo {
+	if x != nil {
+		return x.Load
+	}
+	return nil
+}
+
 type Update struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Tenant        *Update_Tenant         `protobuf:"bytes,2,opt,name=tenant,proto3" json:"tenant,omitempty"`
 	Service       *Update_Service        `protobuf:"bytes,3,opt,name=service,proto3" json:"service,omitempty"`
 	Placement     *Update_Placement      `protobuf:"bytes,4,opt,name=placement,proto3" json:"placement,omitempty"`
+	Status        *ServiceStatus         `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Update) Reset() {
 	*x = Update{}
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[2]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -166,7 +219,7 @@ func (x *Update) String() string {
 func (*Update) ProtoMessage() {}
 
 func (x *Update) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[2]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -179,7 +232,7 @@ func (x *Update) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update.ProtoReflect.Descriptor instead.
 func (*Update) Descriptor() ([]byte, []int) {
-	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{2}
+	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Update) GetName() string {
@@ -210,6 +263,13 @@ func (x *Update) GetPlacement() *Update_Placement {
 	return nil
 }
 
+func (x *Update) GetStatus() *ServiceStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
 type Delete struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Tenant        string                 `protobuf:"bytes,1,opt,name=tenant,proto3" json:"tenant,omitempty"`
@@ -219,7 +279,7 @@ type Delete struct {
 
 func (x *Delete) Reset() {
 	*x = Delete{}
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[3]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -231,7 +291,7 @@ func (x *Delete) String() string {
 func (*Delete) ProtoMessage() {}
 
 func (x *Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[3]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -244,7 +304,7 @@ func (x *Delete) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Delete.ProtoReflect.Descriptor instead.
 func (*Delete) Descriptor() ([]byte, []int) {
-	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{3}
+	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Delete) GetTenant() string {
@@ -263,7 +323,7 @@ type Restore struct {
 
 func (x *Restore) Reset() {
 	*x = Restore{}
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[4]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -275,7 +335,7 @@ func (x *Restore) String() string {
 func (*Restore) ProtoMessage() {}
 
 func (x *Restore) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[4]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -288,7 +348,7 @@ func (x *Restore) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Restore.ProtoReflect.Descriptor instead.
 func (*Restore) Descriptor() ([]byte, []int) {
-	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{4}
+	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Restore) GetSnapshot() *Snapshot {
@@ -312,7 +372,7 @@ type Mutation struct {
 
 func (x *Mutation) Reset() {
 	*x = Mutation{}
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[5]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -324,7 +384,7 @@ func (x *Mutation) String() string {
 func (*Mutation) ProtoMessage() {}
 
 func (x *Mutation) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[5]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -337,7 +397,7 @@ func (x *Mutation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Mutation.ProtoReflect.Descriptor instead.
 func (*Mutation) Descriptor() ([]byte, []int) {
-	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{5}
+	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Mutation) GetMsg() isMutation_Msg {
@@ -405,7 +465,7 @@ type Snapshot struct {
 
 func (x *Snapshot) Reset() {
 	*x = Snapshot{}
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[6]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -417,7 +477,7 @@ func (x *Snapshot) String() string {
 func (*Snapshot) ProtoMessage() {}
 
 func (x *Snapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[6]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -430,7 +490,7 @@ func (x *Snapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Snapshot.ProtoReflect.Descriptor instead.
 func (*Snapshot) Descriptor() ([]byte, []int) {
-	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{6}
+	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Snapshot) GetTenants() []*State {
@@ -449,7 +509,7 @@ type Update_Tenant struct {
 
 func (x *Update_Tenant) Reset() {
 	*x = Update_Tenant{}
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[7]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -461,7 +521,7 @@ func (x *Update_Tenant) String() string {
 func (*Update_Tenant) ProtoMessage() {}
 
 func (x *Update_Tenant) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[7]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -474,7 +534,7 @@ func (x *Update_Tenant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_Tenant.ProtoReflect.Descriptor instead.
 func (*Update_Tenant) Descriptor() ([]byte, []int) {
-	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{2, 0}
+	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{3, 0}
 }
 
 func (x *Update_Tenant) GetUpdated() *pb.TenantInfo {
@@ -494,7 +554,7 @@ type Update_Service struct {
 
 func (x *Update_Service) Reset() {
 	*x = Update_Service{}
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[8]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -506,7 +566,7 @@ func (x *Update_Service) String() string {
 func (*Update_Service) ProtoMessage() {}
 
 func (x *Update_Service) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[8]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -519,7 +579,7 @@ func (x *Update_Service) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_Service.ProtoReflect.Descriptor instead.
 func (*Update_Service) Descriptor() ([]byte, []int) {
-	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{2, 1}
+	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{3, 1}
 }
 
 func (x *Update_Service) GetUpdated() []*ServiceUpdate {
@@ -546,7 +606,7 @@ type Update_Placement struct {
 
 func (x *Update_Placement) Reset() {
 	*x = Update_Placement{}
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[9]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -558,7 +618,7 @@ func (x *Update_Placement) String() string {
 func (*Update_Placement) ProtoMessage() {}
 
 func (x *Update_Placement) ProtoReflect() protoreflect.Message {
-	mi := &file_atoms_splitter_private_state_proto_msgTypes[9]
+	mi := &file_atoms_splitter_private_state_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -571,7 +631,7 @@ func (x *Update_Placement) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Update_Placement.ProtoReflect.Descriptor instead.
 func (*Update_Placement) Descriptor() ([]byte, []int) {
-	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{2, 2}
+	return file_atoms_splitter_private_state_proto_rawDescGZIP(), []int{3, 2}
 }
 
 func (x *Update_Placement) GetUpdated() []*InternalPlacementInfo {
@@ -592,22 +652,26 @@ var File_atoms_splitter_private_state_proto protoreflect.FileDescriptor
 
 const file_atoms_splitter_private_state_proto_rawDesc = "" +
 	"\n" +
-	"\"atoms/splitter/private/state.proto\x12\x16atoms.splitter.private\x1a\x1aatoms/splitter/model.proto\x1a\x1fatoms/splitter/management.proto\x1a\x1eatoms/splitter/placement.proto\x1a&atoms/splitter/private/placement.proto\"\xc5\x01\n" +
+	"\"atoms/splitter/private/state.proto\x12\x16atoms.splitter.private\x1a\x1aatoms/splitter/model.proto\x1a\x1fatoms/splitter/management.proto\x1a\x1eatoms/splitter/placement.proto\x1a!atoms/splitter/private/load.proto\x1a&atoms/splitter/private/placement.proto\"\x88\x02\n" +
 	"\x05State\x122\n" +
 	"\x06tenant\x18\x01 \x01(\v2\x1a.atoms.splitter.TenantInfoR\x06tenant\x129\n" +
 	"\bservices\x18\x02 \x03(\v2\x1d.atoms.splitter.ServiceInfoExR\bservices\x12M\n" +
 	"\n" +
 	"placements\x18\x03 \x03(\v2-.atoms.splitter.private.InternalPlacementInfoR\n" +
-	"placements\"\xb7\x01\n" +
+	"placements\x12A\n" +
+	"\bstatuses\x18\x04 \x03(\v2%.atoms.splitter.private.ServiceStatusR\bstatuses\"\xb7\x01\n" +
 	"\rServiceUpdate\x125\n" +
 	"\aservice\x18\x01 \x01(\v2\x1b.atoms.splitter.ServiceInfoR\aservice\x120\n" +
 	"\aupdated\x18\x02 \x03(\v2\x16.atoms.splitter.DomainR\aupdated\x12=\n" +
-	"\aremoved\x18\x03 \x03(\v2#.atoms.splitter.QualifiedDomainNameR\aremoved\"\xcb\x04\n" +
+	"\aremoved\x18\x03 \x03(\v2#.atoms.splitter.QualifiedDomainNameR\aremoved\"L\n" +
+	"\rServiceStatus\x12;\n" +
+	"\x04load\x18\x01 \x01(\v2'.atoms.splitter.private.ServiceLoadInfoR\x04load\"\x8a\x05\n" +
 	"\x06Update\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12=\n" +
 	"\x06tenant\x18\x02 \x01(\v2%.atoms.splitter.private.Update.TenantR\x06tenant\x12@\n" +
 	"\aservice\x18\x03 \x01(\v2&.atoms.splitter.private.Update.ServiceR\aservice\x12F\n" +
-	"\tplacement\x18\x04 \x01(\v2(.atoms.splitter.private.Update.PlacementR\tplacement\x1a>\n" +
+	"\tplacement\x18\x04 \x01(\v2(.atoms.splitter.private.Update.PlacementR\tplacement\x12=\n" +
+	"\x06status\x18\x05 \x01(\v2%.atoms.splitter.private.ServiceStatusR\x06status\x1a>\n" +
 	"\x06Tenant\x124\n" +
 	"\aupdated\x18\x01 \x01(\v2\x1a.atoms.splitter.TenantInfoR\aupdated\x1a\x8a\x01\n" +
 	"\aService\x12?\n" +
@@ -640,52 +704,57 @@ func file_atoms_splitter_private_state_proto_rawDescGZIP() []byte {
 	return file_atoms_splitter_private_state_proto_rawDescData
 }
 
-var file_atoms_splitter_private_state_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_atoms_splitter_private_state_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_atoms_splitter_private_state_proto_goTypes = []any{
 	(*State)(nil),                     // 0: atoms.splitter.private.State
 	(*ServiceUpdate)(nil),             // 1: atoms.splitter.private.ServiceUpdate
-	(*Update)(nil),                    // 2: atoms.splitter.private.Update
-	(*Delete)(nil),                    // 3: atoms.splitter.private.Delete
-	(*Restore)(nil),                   // 4: atoms.splitter.private.Restore
-	(*Mutation)(nil),                  // 5: atoms.splitter.private.Mutation
-	(*Snapshot)(nil),                  // 6: atoms.splitter.private.Snapshot
-	(*Update_Tenant)(nil),             // 7: atoms.splitter.private.Update.Tenant
-	(*Update_Service)(nil),            // 8: atoms.splitter.private.Update.Service
-	(*Update_Placement)(nil),          // 9: atoms.splitter.private.Update.Placement
-	(*pb.TenantInfo)(nil),             // 10: atoms.splitter.TenantInfo
-	(*pb.ServiceInfoEx)(nil),          // 11: atoms.splitter.ServiceInfoEx
-	(*InternalPlacementInfo)(nil),     // 12: atoms.splitter.private.InternalPlacementInfo
-	(*pb.ServiceInfo)(nil),            // 13: atoms.splitter.ServiceInfo
-	(*pb.Domain)(nil),                 // 14: atoms.splitter.Domain
-	(*pb.QualifiedDomainName)(nil),    // 15: atoms.splitter.QualifiedDomainName
-	(*pb.QualifiedServiceName)(nil),   // 16: atoms.splitter.QualifiedServiceName
-	(*pb.QualifiedPlacementName)(nil), // 17: atoms.splitter.QualifiedPlacementName
+	(*ServiceStatus)(nil),             // 2: atoms.splitter.private.ServiceStatus
+	(*Update)(nil),                    // 3: atoms.splitter.private.Update
+	(*Delete)(nil),                    // 4: atoms.splitter.private.Delete
+	(*Restore)(nil),                   // 5: atoms.splitter.private.Restore
+	(*Mutation)(nil),                  // 6: atoms.splitter.private.Mutation
+	(*Snapshot)(nil),                  // 7: atoms.splitter.private.Snapshot
+	(*Update_Tenant)(nil),             // 8: atoms.splitter.private.Update.Tenant
+	(*Update_Service)(nil),            // 9: atoms.splitter.private.Update.Service
+	(*Update_Placement)(nil),          // 10: atoms.splitter.private.Update.Placement
+	(*pb.TenantInfo)(nil),             // 11: atoms.splitter.TenantInfo
+	(*pb.ServiceInfoEx)(nil),          // 12: atoms.splitter.ServiceInfoEx
+	(*InternalPlacementInfo)(nil),     // 13: atoms.splitter.private.InternalPlacementInfo
+	(*pb.ServiceInfo)(nil),            // 14: atoms.splitter.ServiceInfo
+	(*pb.Domain)(nil),                 // 15: atoms.splitter.Domain
+	(*pb.QualifiedDomainName)(nil),    // 16: atoms.splitter.QualifiedDomainName
+	(*ServiceLoadInfo)(nil),           // 17: atoms.splitter.private.ServiceLoadInfo
+	(*pb.QualifiedServiceName)(nil),   // 18: atoms.splitter.QualifiedServiceName
+	(*pb.QualifiedPlacementName)(nil), // 19: atoms.splitter.QualifiedPlacementName
 }
 var file_atoms_splitter_private_state_proto_depIdxs = []int32{
-	10, // 0: atoms.splitter.private.State.tenant:type_name -> atoms.splitter.TenantInfo
-	11, // 1: atoms.splitter.private.State.services:type_name -> atoms.splitter.ServiceInfoEx
-	12, // 2: atoms.splitter.private.State.placements:type_name -> atoms.splitter.private.InternalPlacementInfo
-	13, // 3: atoms.splitter.private.ServiceUpdate.service:type_name -> atoms.splitter.ServiceInfo
-	14, // 4: atoms.splitter.private.ServiceUpdate.updated:type_name -> atoms.splitter.Domain
-	15, // 5: atoms.splitter.private.ServiceUpdate.removed:type_name -> atoms.splitter.QualifiedDomainName
-	7,  // 6: atoms.splitter.private.Update.tenant:type_name -> atoms.splitter.private.Update.Tenant
-	8,  // 7: atoms.splitter.private.Update.service:type_name -> atoms.splitter.private.Update.Service
-	9,  // 8: atoms.splitter.private.Update.placement:type_name -> atoms.splitter.private.Update.Placement
-	6,  // 9: atoms.splitter.private.Restore.snapshot:type_name -> atoms.splitter.private.Snapshot
-	2,  // 10: atoms.splitter.private.Mutation.update:type_name -> atoms.splitter.private.Update
-	3,  // 11: atoms.splitter.private.Mutation.delete:type_name -> atoms.splitter.private.Delete
-	4,  // 12: atoms.splitter.private.Mutation.restore:type_name -> atoms.splitter.private.Restore
-	0,  // 13: atoms.splitter.private.Snapshot.tenants:type_name -> atoms.splitter.private.State
-	10, // 14: atoms.splitter.private.Update.Tenant.updated:type_name -> atoms.splitter.TenantInfo
-	1,  // 15: atoms.splitter.private.Update.Service.updated:type_name -> atoms.splitter.private.ServiceUpdate
-	16, // 16: atoms.splitter.private.Update.Service.removed:type_name -> atoms.splitter.QualifiedServiceName
-	12, // 17: atoms.splitter.private.Update.Placement.updated:type_name -> atoms.splitter.private.InternalPlacementInfo
-	17, // 18: atoms.splitter.private.Update.Placement.removed:type_name -> atoms.splitter.QualifiedPlacementName
-	19, // [19:19] is the sub-list for method output_type
-	19, // [19:19] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	11, // 0: atoms.splitter.private.State.tenant:type_name -> atoms.splitter.TenantInfo
+	12, // 1: atoms.splitter.private.State.services:type_name -> atoms.splitter.ServiceInfoEx
+	13, // 2: atoms.splitter.private.State.placements:type_name -> atoms.splitter.private.InternalPlacementInfo
+	2,  // 3: atoms.splitter.private.State.statuses:type_name -> atoms.splitter.private.ServiceStatus
+	14, // 4: atoms.splitter.private.ServiceUpdate.service:type_name -> atoms.splitter.ServiceInfo
+	15, // 5: atoms.splitter.private.ServiceUpdate.updated:type_name -> atoms.splitter.Domain
+	16, // 6: atoms.splitter.private.ServiceUpdate.removed:type_name -> atoms.splitter.QualifiedDomainName
+	17, // 7: atoms.splitter.private.ServiceStatus.load:type_name -> atoms.splitter.private.ServiceLoadInfo
+	8,  // 8: atoms.splitter.private.Update.tenant:type_name -> atoms.splitter.private.Update.Tenant
+	9,  // 9: atoms.splitter.private.Update.service:type_name -> atoms.splitter.private.Update.Service
+	10, // 10: atoms.splitter.private.Update.placement:type_name -> atoms.splitter.private.Update.Placement
+	2,  // 11: atoms.splitter.private.Update.status:type_name -> atoms.splitter.private.ServiceStatus
+	7,  // 12: atoms.splitter.private.Restore.snapshot:type_name -> atoms.splitter.private.Snapshot
+	3,  // 13: atoms.splitter.private.Mutation.update:type_name -> atoms.splitter.private.Update
+	4,  // 14: atoms.splitter.private.Mutation.delete:type_name -> atoms.splitter.private.Delete
+	5,  // 15: atoms.splitter.private.Mutation.restore:type_name -> atoms.splitter.private.Restore
+	0,  // 16: atoms.splitter.private.Snapshot.tenants:type_name -> atoms.splitter.private.State
+	11, // 17: atoms.splitter.private.Update.Tenant.updated:type_name -> atoms.splitter.TenantInfo
+	1,  // 18: atoms.splitter.private.Update.Service.updated:type_name -> atoms.splitter.private.ServiceUpdate
+	18, // 19: atoms.splitter.private.Update.Service.removed:type_name -> atoms.splitter.QualifiedServiceName
+	13, // 20: atoms.splitter.private.Update.Placement.updated:type_name -> atoms.splitter.private.InternalPlacementInfo
+	19, // 21: atoms.splitter.private.Update.Placement.removed:type_name -> atoms.splitter.QualifiedPlacementName
+	22, // [22:22] is the sub-list for method output_type
+	22, // [22:22] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_atoms_splitter_private_state_proto_init() }
@@ -693,8 +762,9 @@ func file_atoms_splitter_private_state_proto_init() {
 	if File_atoms_splitter_private_state_proto != nil {
 		return
 	}
+	file_atoms_splitter_private_load_proto_init()
 	file_atoms_splitter_private_placement_proto_init()
-	file_atoms_splitter_private_state_proto_msgTypes[5].OneofWrappers = []any{
+	file_atoms_splitter_private_state_proto_msgTypes[6].OneofWrappers = []any{
 		(*Mutation_Update)(nil),
 		(*Mutation_Delete)(nil),
 		(*Mutation_Restore)(nil),
@@ -705,7 +775,7 @@ func file_atoms_splitter_private_state_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_atoms_splitter_private_state_proto_rawDesc), len(file_atoms_splitter_private_state_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/core/storage.go
+++ b/pkg/core/storage.go
@@ -44,11 +44,12 @@ type State struct {
 	pb *splitterprivatepb.State
 }
 
-func NewState(tenant model.TenantInfo, services []model.ServiceInfoEx, placements []InternalPlacementInfo) State {
+func NewState(tenant model.TenantInfo, services []model.ServiceInfoEx, placements []InternalPlacementInfo, statuses []ServiceStatus) State {
 	return State{pb: &splitterprivatepb.State{
 		Tenant:     model.UnwrapTenantInfo(tenant),
 		Services:   slicex.Map(services, model.UnwrapServiceInfoEx),
 		Placements: slicex.Map(placements, UnwrapInternalPlacementInfo),
+		Statuses:   slicex.Map(statuses, UnwrapServiceStatus),
 	}}
 }
 
@@ -70,6 +71,10 @@ func (s State) Services() []model.ServiceInfoEx {
 
 func (s State) Placements() []InternalPlacementInfo {
 	return slicex.Map(s.pb.GetPlacements(), WrapInternalPlacementInfo)
+}
+
+func (s State) Statuses() []ServiceStatus {
+	return slicex.Map(s.pb.GetStatuses(), WrapServiceStatus)
 }
 
 func (s State) String() string {
@@ -155,6 +160,13 @@ func NewPlacementRemoval(t model.QualifiedPlacementName) Update {
 	})
 }
 
+func NewServiceStatusUpdate(s ServiceStatus) Update {
+	return WrapUpdate(&splitterprivatepb.Update{
+		Name:   string(s.Load().Service().Tenant),
+		Status: UnwrapServiceStatus(s),
+	})
+}
+
 func WrapUpdate(pb *splitterprivatepb.Update) Update {
 	return Update{pb: pb}
 }
@@ -183,6 +195,24 @@ func (s Update) ServicesRemoved() []model.QualifiedServiceName {
 		ret, _ := model.ParseQualifiedServiceName(t)
 		return ret
 	})
+}
+
+func (s Update) ServiceStatus() (ServiceStatus, bool) {
+	status := s.pb.GetStatus()
+	if status == nil {
+		return ServiceStatus{}, false
+	}
+
+	return WrapServiceStatus(status), true
+}
+
+// IsStateUpdated indicates if Update contains any State update, including Tenant, Service and Placements
+func (s Update) IsStateUpdated() bool {
+	if _, ok := s.TenantUpdated(); ok {
+		return true
+	}
+
+	return len(s.ServicesUpdated()) > 0 || len(s.ServicesRemoved()) > 0 || len(s.PlacementsUpdated()) > 0 || len(s.PlacementsRemoved()) > 0
 }
 
 // ServiceUpdate is an incremental update to a single service.
@@ -284,4 +314,34 @@ func (s Restore) Snapshot() Snapshot {
 
 func (s Restore) Size() int {
 	return protox.Size(s.pb)
+}
+
+type ServiceStatus struct {
+	pb *splitterprivatepb.ServiceStatus
+}
+
+func NewServiceStatus(serviceLoad ServiceLoadInfo) ServiceStatus {
+	return ServiceStatus{pb: &splitterprivatepb.ServiceStatus{
+		Load: UnwrapServiceLoadInfo(serviceLoad),
+	}}
+}
+
+func WrapServiceStatus(pb *splitterprivatepb.ServiceStatus) ServiceStatus {
+	return ServiceStatus{pb: pb}
+}
+
+func UnwrapServiceStatus(m ServiceStatus) *splitterprivatepb.ServiceStatus {
+	return m.pb
+}
+
+func (m ServiceStatus) Load() ServiceLoadInfo {
+	return WrapServiceLoadInfo(m.pb.GetLoad())
+}
+
+func (m ServiceStatus) String() string {
+	return protox.MarshalTextString(m.pb)
+}
+
+func (m ServiceStatus) Equal(other ServiceStatus) bool {
+	return protox.Equal(m.pb, other.pb)
 }

--- a/pkg/service/coordinator/coordinator.go
+++ b/pkg/service/coordinator/coordinator.go
@@ -513,6 +513,7 @@ func (c *coordinator) init(ctx context.Context, state core.State, updates <-chan
 
 	start := time.Now()
 
+	// TODO: restore trackers from ServiceStatus
 	c.cache.Restore(core.NewSnapshot(state))
 
 	tenant, ok := c.cache.Tenant(c.name.Tenant)

--- a/pkg/service/coordinator/coordinator_test.go
+++ b/pkg/service/coordinator/coordinator_test.go
@@ -1221,6 +1221,7 @@ func setupWithServiceConfig(ctx context.Context, t *testing.T, domains []model.D
 		model.NewTenantInfo(tenant, 1, time.Now()),
 		[]model.ServiceInfoEx{model.NewServiceInfoEx(model.NewServiceInfo(service, 1, time.Now()), domains)},
 		nil, // TODO(jhhurwitz): 12/13/23 Test placements when implemented
+		nil,
 	)
 
 	updates := make(chan core.Update)

--- a/pkg/service/leader/BUILD.bazel
+++ b/pkg/service/leader/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
 go_test(
     name = "leader_test",
     srcs = glob(["*_test.go"]),
+    visibility = ["//visibility:private"],
     deps = [
         ":leader",
         "//lib/service/location",
@@ -46,7 +47,9 @@ go_test(
         "//pkg/model",
         "//pkg/storage",
         "//pkg/storage/memory",
+        "//proto/atoms/splitter:splitter_go_proto",
         "//proto/atoms/splitter/private:private_go_proto",
+        "@co_atoms_go_lib//chanx",
         "@co_atoms_go_lib//testing/assertx",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/service/leader/allocation_test.go
+++ b/pkg/service/leader/allocation_test.go
@@ -84,10 +84,10 @@ func TestControl(t *testing.T) {
 	st1 := core.NewState(model.NewTenantInfo(t1, 1, time.Time{}), []model.ServiceInfoEx{
 		model.NewServiceInfoEx(model.NewServiceInfo(s1, 1, time.Time{}), nil),
 		model.NewServiceInfoEx(model.NewServiceInfo(s2, 1, time.Time{}), nil),
-	}, nil)
+	}, nil, nil)
 	st2 := core.NewState(model.NewTenantInfo(t2, 1, time.Time{}), []model.ServiceInfoEx{
 		model.NewServiceInfoEx(model.NewServiceInfo(s3, 1, time.Time{}), nil),
-	}, nil)
+	}, nil, nil)
 
 	ctrl := leader.NewControl(core.NewSnapshot(st1, st2))
 

--- a/pkg/service/leader/leader.go
+++ b/pkg/service/leader/leader.go
@@ -310,6 +310,10 @@ steady:
 				return
 			}
 
+			if !upd.IsStateUpdated() {
+				break // cache only; do not refresh allocation or notify workers
+			}
+
 			l.refresh(ctx)
 			l.update(ctx, upd)
 			l.allocate(ctx, time.Now(), false)
@@ -366,8 +370,8 @@ func (l *leader) handleMessage(ctx context.Context, w *workerSession, m Message)
 		l.handleRelinquished(ctx, w, relinquished)
 
 	case msg.IsServiceStatus():
-		// TODO: handleServiceStatus
-		log.Debugf(ctx, "Received service status message: %v", msg)
+		serviceStatus, _ := msg.ServiceStatus()
+		l.handleServiceStatus(ctx, serviceStatus)
 
 	default:
 		log.Errorf(ctx, "Internal: unexpected worker message: %v", msg)
@@ -437,6 +441,13 @@ func (l *leader) handleRelinquished(ctx context.Context, w *workerSession, relin
 
 	// (3) Broadcast cluster changes
 	l.broadcast(ctx, now)
+}
+
+func (l *leader) handleServiceStatus(ctx context.Context, status core.ServiceStatusMessage) {
+	err := l.writer.UpdateServiceStatusAsync(ctx, core.NewServiceStatus(status.Load()))
+	if err != nil {
+		log.Errorf(ctx, "Failed to update service status %v: %v", status, err)
+	}
 }
 
 func (l *leader) connect(ctx context.Context, now time.Time, sid session.ID, register RegisterMessage, in <-chan Message) (*workerSession, <-chan Message) {

--- a/pkg/service/leader/leader_test.go
+++ b/pkg/service/leader/leader_test.go
@@ -18,6 +18,8 @@ import (
 	"go.atoms.co/splitter/pkg/storage"
 	"go.atoms.co/splitter/pkg/storage/memory"
 	splitterprivatepb "go.atoms.co/splitter/pb/private"
+	splitterpb "go.atoms.co/splitter/pb"
+	"go.atoms.co/lib/chanx"
 )
 
 const (
@@ -188,6 +190,83 @@ func TestLeader_Operations(t *testing.T) {
 	assert.Len(t, snap.GetSnapshot().GetTenants(), 2)
 }
 
+func TestLeader_HandleUpdate(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		loc := location.New("centralus", "splitter-0")
+
+		cfg := model.NewServiceConfig(model.WithTrackLoad(true))
+		service, err := model.NewService(s1, time.Now(), model.WithServiceConfig(cfg))
+		require.NoError(t, err)
+
+		qdn := model.QualifiedDomainName{Service: service.Name(), Domain: model.DomainName("domain")}
+		domain, err := model.NewDomain(qdn, model.Unit, time.Now())
+		require.NoError(t, err)
+		db := setupWithDomains(t, ctx, service, domain)
+
+		l := leader.New(ctx, loc, db, leader.WithFastActivation())
+		defer l.Close()
+		<-l.Initialized().Closed()
+
+		worker := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
+		in := make(chan leader.Message, 2)
+		in <- leader.NewRegister(worker)
+
+		out, err := l.Join(ctx, session.NewID(), in)
+		require.NoError(t, err, "worker failed to join leader")
+		readFn(t, out, isAssign)
+		synctest.Wait()
+		chanx.Clear(out)
+
+		// (1) Test Status update
+		snap := core.NewP2QuantileSnapshot(
+			0.5,
+			[]float64{10, 10, 10, 10, 10},
+			[]uint64{1, 2, 3, 4, 10},
+			[]float64{1, 2, 3, 4, 10},
+		)
+		trackers := core.NewDomainTrackerSnapshot(time.Now(), snap, nil)
+		status := core.NewServiceStatusMessage(core.NewServiceLoadInfo(service.Name(), []core.DomainLoadInfo{
+			core.NewDomainLoadInfo(domain.Name().Domain, trackers, nil),
+		}))
+		in <- leader.NewServiceStatus(status)
+		synctest.Wait()
+
+		resp, err := l.Handle(ctx, leader.NewHandleOperationRequest(&splitterprivatepb.OperationRequest{
+			Req: &splitterprivatepb.OperationRequest_Snapshot{Snapshot: &splitterprivatepb.SnapshotRequest{}},
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetOperation())
+		synctest.Wait()
+
+		// snapshot contains ServiceStatus
+		snapshot := core.WrapSnapshot(resp.GetOperation().GetSnapshot().GetSnapshot())
+		require.True(t, snapshotHasServiceStatus(snapshot, service.Name(), domain.Name()))
+
+		// no message sent to worker
+		_, ok := chanx.TryRead(out, time.Millisecond)
+		require.False(t, ok)
+
+		// (2) Test State update
+		resp, err = l.Handle(ctx, leader.NewHandleServiceRequest(&splitterprivatepb.ServiceRequest{
+			Req: &splitterprivatepb.ServiceRequest_Update{
+				Update: &splitterpb.UpdateServiceRequest{
+					Name:    service.Name().ToProto(),
+					Version: int64(snapshot.Tenants()[0].Services()[0].Info().Version()),
+					Config:  model.UnwrapServiceConfig(model.NewServiceConfig(model.WithTrackLoad(false))),
+				},
+			},
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetService().GetUpdate())
+
+		// Update message send to worker
+		update := readFn(t, out, isUpdate)
+		assert.Equal(t, service.Name(), update.Grant().Service())
+		assert.True(t, update.State().IsStateUpdated())
+	})
+}
+
 func setup(t *testing.T, ctx context.Context, services ...model.Service) storage.Storage {
 	db := memory.New()
 
@@ -204,6 +283,46 @@ func setup(t *testing.T, ctx context.Context, services ...model.Service) storage
 	return db
 }
 
+func setupWithDomains(t *testing.T, ctx context.Context, service model.Service, domains ...model.Domain) storage.Storage {
+	db := memory.New()
+
+	tenant, err := model.NewTenant(service.Name().Tenant, time.Now())
+	require.NoError(t, err)
+
+	err = db.Update(ctx, core.NewTenantUpdate(model.NewTenantInfo(tenant, 1, time.Now())))
+	require.NoError(t, err)
+
+	serviceInfo := model.NewServiceInfo(service, 1, time.Now())
+	err = db.Update(ctx, core.NewServiceUpdate(serviceInfo))
+	require.NoError(t, err)
+
+	for _, domain := range domains {
+		serviceInfo = model.NewServiceInfo(service, serviceInfo.Version()+1, time.Now())
+		err = db.Update(ctx, core.NewDomainUpdate(serviceInfo, domain))
+		require.NoError(t, err)
+	}
+
+	return db
+}
+
+func snapshotHasServiceStatus(snapshot core.Snapshot, service model.QualifiedServiceName, domain model.QualifiedDomainName) bool {
+	for _, state := range snapshot.Tenants() {
+		for _, status := range state.Statuses() {
+			load := status.Load()
+			if load.Service() != service {
+				continue
+			}
+
+			for _, domainLoad := range load.Domains() {
+				if domainLoad.DomainName() == domain.Domain {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 func isAssign(msg leader.Message) (leader.AssignMessage, bool) {
 	if msg.IsWorkerMessage() {
 		w, _ := msg.WorkerMessage()
@@ -218,6 +337,14 @@ func isRevoke(msg leader.Message) (leader.RevokeMessage, bool) {
 		return w.Revoke()
 	}
 	return leader.RevokeMessage{}, false
+}
+
+func isUpdate(msg leader.Message) (leader.UpdateMessage, bool) {
+	if msg.IsWorkerMessage() {
+		w, _ := msg.WorkerMessage()
+		return w.Update()
+	}
+	return leader.UpdateMessage{}, false
 }
 
 func readFn[T any](t *testing.T, in <-chan leader.Message, fn func(message leader.Message) (T, bool)) T {

--- a/pkg/service/leader/writer.go
+++ b/pkg/service/leader/writer.go
@@ -606,6 +606,10 @@ func (w *Writer) updateAsync(ctx context.Context, upd core.Update) iox.AsyncClos
 		log.Fatalf(ctx, "Internal: pre-commit cache inconsistent with writer: %v", err)
 	}
 
+	return w.applyUpdateAsync(ctx, upd)
+}
+
+func (w *Writer) applyUpdateAsync(ctx context.Context, upd core.Update) iox.AsyncCloser {
 	done := iox.NewAsyncCloser()
 	w.pool.Chan() <- func() {
 		defer done.Close()
@@ -625,6 +629,22 @@ func (w *Writer) updateAsync(ctx context.Context, upd core.Update) iox.AsyncClos
 
 	}
 	return done
+}
+
+// UpdateServiceStatusAsync attempts to update ServiceStatus. Does not wait for response.
+func (w *Writer) UpdateServiceStatusAsync(ctx context.Context, status core.ServiceStatus) error {
+	upd := core.NewServiceStatusUpdate(status)
+	if err := w.cache.Update(upd, true); err != nil {
+		return err
+	}
+
+	if len(w.pool.Chan()) == pendingApplyCapacity {
+		log.Warnf(ctx, "Internal: pending applies reached internal limit: %v", pendingApplyCapacity)
+		return model.ErrOverloaded
+	}
+
+	_ = w.applyUpdateAsync(ctx, upd)
+	return nil
 }
 
 func (w *Writer) deleteAsync(ctx context.Context, del core.Delete) iox.AsyncCloser {

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "storage",
@@ -12,5 +12,16 @@ go_library(
         "//pkg/core",
         "//pkg/model",
         "@co_atoms_go_lib//mapx",
+    ],
+)
+
+go_test(
+    name = "storage_test",
+    srcs = glob(["*_test.go"]),
+    embed = [":storage"],
+    deps = [
+        "//pkg/core",
+        "//pkg/model",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -12,6 +12,7 @@ type tenantInfo struct {
 	info       model.TenantInfo
 	services   map[model.QualifiedServiceName]model.ServiceInfoEx
 	placements map[model.QualifiedPlacementName]core.InternalPlacementInfo
+	statuses   map[model.QualifiedServiceName]core.ServiceStatus
 }
 
 // Cache is an in-memory cache of state. Not thread-safe.
@@ -89,7 +90,11 @@ func (c *Cache) Placement(name model.QualifiedPlacementName) (core.InternalPlace
 func (c *Cache) ServiceState(name model.QualifiedServiceName) (core.State, bool) {
 	if t, ok := c.tenants[name.Tenant]; ok {
 		if s, ok := t.services[name]; ok {
-			return core.NewState(t.info, []model.ServiceInfoEx{s}, mapx.Values(t.placements)), ok
+			var statuses []core.ServiceStatus
+			if serviceStatus, ok := c.ServiceStatus(name); ok {
+				statuses = []core.ServiceStatus{serviceStatus}
+			}
+			return core.NewState(t.info, []model.ServiceInfoEx{s}, mapx.Values(t.placements), statuses), ok
 		}
 	}
 	return core.State{}, false
@@ -97,14 +102,28 @@ func (c *Cache) ServiceState(name model.QualifiedServiceName) (core.State, bool)
 
 func (c *Cache) State(name model.TenantName) (core.State, bool) {
 	if t, ok := c.tenants[name]; ok {
-		return core.NewState(t.info, mapx.Values(t.services), mapx.Values(t.placements)), ok
+		return core.NewState(t.info, mapx.Values(t.services), mapx.Values(t.placements), mapx.Values(t.statuses)), ok
 	}
 	return core.State{}, false
 }
 
+func (c *Cache) ServiceStatus(name model.QualifiedServiceName) (core.ServiceStatus, bool) {
+	t, ok := c.tenants[name.Tenant]
+	if !ok {
+		return core.ServiceStatus{}, false
+	}
+
+	status, ok := t.statuses[name]
+	if !ok {
+		return core.ServiceStatus{}, false
+	}
+
+	return status, true
+}
+
 func (c *Cache) Snapshot() core.Snapshot {
 	return core.NewSnapshot(mapx.MapValues(c.tenants, func(v *tenantInfo) core.State {
-		return core.NewState(v.info, mapx.Values(v.services), mapx.Values(v.placements))
+		return core.NewState(v.info, mapx.Values(v.services), mapx.Values(v.placements), mapx.Values(v.statuses))
 	})...)
 }
 
@@ -116,6 +135,7 @@ func (c *Cache) Restore(snapshot core.Snapshot) {
 			info:       info,
 			services:   mapx.New(s.Services(), model.ServiceInfoEx.Name),
 			placements: mapx.New(s.Placements(), core.InternalPlacementInfo.Name),
+			statuses:   mapx.New(s.Statuses(), func(v core.ServiceStatus) model.QualifiedServiceName { return v.Load().Service() }),
 		}
 	}
 }
@@ -137,14 +157,22 @@ func (c *Cache) Update(update core.Update, strict bool) error {
 		}
 		for _, remove := range upd.DomainsRemoved() {
 			delete(domains, remove)
+			// do not remove domainLoad from status as it will be removed after tracker rotation.
 		}
+
 		s.services[upd.Service().Name()] = model.NewServiceInfoEx(upd.Service(), mapx.Values(domains))
+
+		// update service config to disable TrackLoad
+		if !upd.Service().Service().Config().TrackLoad() {
+			delete(s.statuses, upd.Service().Name())
+		}
 	}
 	for _, rm := range update.ServicesRemoved() {
 		if _, ok := s.services[rm]; !ok {
 			return fmt.Errorf("service %v not found", rm)
 		}
 		delete(s.services, rm)
+		delete(s.statuses, rm)
 	}
 
 	for _, upd := range update.PlacementsUpdated() {
@@ -162,9 +190,27 @@ func (c *Cache) Update(update core.Update, strict bool) error {
 	}
 
 	c.tenants[update.Name()] = s
+
+	status, ok := update.ServiceStatus()
+	if !ok {
+		return nil
+	}
+
+	service := status.Load().Service()
+	info, ok := c.Service(service)
+	if !ok || !info.Service().Config().TrackLoad() {
+		// service or tenant does not exist, or TrackLoad is not enabled
+		return nil
+	}
+
+	if t, ok := c.tenants[service.Tenant]; ok {
+		t.statuses[service] = status
+	}
+
 	return nil
 }
 
+// Delete deletes a tenant
 func (c *Cache) Delete(del core.Delete) error {
 	if _, ok := c.tenants[del.Tenant()]; !ok {
 		return fmt.Errorf("tenant %v not found", del.Tenant())
@@ -189,6 +235,7 @@ func (c *Cache) cloneTenant(update core.Update, strict bool) (*tenantInfo, error
 			info:       info,
 			services:   map[model.QualifiedServiceName]model.ServiceInfoEx{},
 			placements: map[model.QualifiedPlacementName]core.InternalPlacementInfo{},
+			statuses:   map[model.QualifiedServiceName]core.ServiceStatus{},
 		}, nil
 	}
 
@@ -196,6 +243,7 @@ func (c *Cache) cloneTenant(update core.Update, strict bool) (*tenantInfo, error
 		info:       s.info,
 		services:   mapx.Clone(s.services),
 		placements: mapx.Clone(s.placements),
+		statuses:   mapx.Clone(s.statuses),
 	}
 
 	if info, ok := update.TenantUpdated(); ok {

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -1,0 +1,186 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.atoms.co/splitter/pkg/core"
+	"go.atoms.co/splitter/pkg/model"
+)
+
+const (
+	tenantName  model.TenantName  = "tenantName"
+	serviceName model.ServiceName = "serviceName"
+)
+
+var qsn = model.QualifiedServiceName{Tenant: tenantName, Service: serviceName}
+
+func TestCache_SnapshotAndRestoreStatus(t *testing.T) {
+	deps := createDeps(t, false)
+
+	_, ok := deps.cache.ServiceStatus(deps.service.Name())
+	require.False(t, ok)
+
+	restored := NewCache()
+	restored.Restore(deps.cache.Snapshot())
+	_, ok = restored.ServiceStatus(deps.service.Name())
+	require.False(t, ok)
+
+	enabledCfg := model.NewServiceConfig(model.WithTrackLoad(true))
+	service, err := model.UpdateService(deps.service, model.WithServiceConfig(enabledCfg))
+	require.NoError(t, err)
+	serviceInfo := model.NewServiceInfo(service, deps.serviceInfo.Version()+1, time.Now())
+	require.NoError(t, restored.Update(core.NewServiceUpdate(serviceInfo), false))
+	require.NoError(t, restored.Update(core.NewServiceStatusUpdate(serviceStatus(service.Name(), domainLoad(deps.domain.Name()))), false))
+	_, ok = restored.ServiceStatus(service.Name())
+	require.True(t, ok)
+
+	restored2 := NewCache()
+	restored2.Restore(restored.Snapshot())
+
+	tenant, ok := restored2.tenants[tenantName]
+	require.True(t, ok)
+	require.Contains(t, tenant.statuses, service.Name())
+
+	_, ok = restored2.ServiceStatus(service.Name())
+	require.True(t, ok)
+}
+
+func TestCache_StatusRemoval(t *testing.T) {
+	t.Run("tenant removed", func(t *testing.T) {
+		deps := createDeps(t, true)
+		require.NoError(t, deps.cache.Update(core.NewServiceStatusUpdate(serviceStatus(deps.service.Name(), domainLoad(deps.domain.Name()))), false))
+		_, ok := deps.cache.ServiceStatus(deps.service.Name())
+		require.True(t, ok)
+
+		require.NoError(t, deps.cache.Delete(core.NewDelete(tenantName)))
+		_, ok = deps.cache.ServiceStatus(deps.service.Name())
+		require.False(t, ok)
+
+		snap := deps.cache.Snapshot()
+		require.Empty(t, snap.Tenants())
+		require.False(t, ok)
+	})
+
+	t.Run("service removed", func(t *testing.T) {
+		deps := createDeps(t, true)
+		require.NoError(t, deps.cache.Update(core.NewServiceStatusUpdate(serviceStatus(deps.service.Name(), domainLoad(deps.domain.Name()))), false))
+		_, ok := deps.cache.ServiceStatus(deps.service.Name())
+		require.True(t, ok)
+
+		require.NoError(t, deps.cache.Update(core.NewServiceRemoval(deps.service.Name()), false))
+		_, ok = deps.cache.ServiceStatus(deps.service.Name())
+		require.False(t, ok)
+
+		snap := deps.cache.Snapshot()
+		require.Empty(t, snap.Tenants()[0].Statuses())
+	})
+
+	t.Run("service track load disabled", func(t *testing.T) {
+		deps := createDeps(t, true)
+		require.NoError(t, deps.cache.Update(core.NewServiceStatusUpdate(serviceStatus(deps.service.Name(), domainLoad(deps.domain.Name()))), false))
+		_, ok := deps.cache.ServiceStatus(deps.service.Name())
+		require.True(t, ok)
+
+		cfg := model.NewServiceConfig(model.WithTrackLoad(false))
+		service, err := model.UpdateService(deps.service, model.WithServiceConfig(cfg))
+		require.NoError(t, err)
+
+		serviceInfo := model.NewServiceInfo(service, deps.serviceInfo.Version()+1, time.Now())
+		require.NoError(t, deps.cache.Update(core.NewServiceUpdate(serviceInfo), false))
+
+		_, ok = deps.cache.ServiceStatus(deps.service.Name())
+		require.False(t, ok)
+
+		snap := deps.cache.Snapshot()
+		require.Empty(t, snap.Tenants()[0].Statuses())
+		_, ok = deps.cache.ServiceStatus(deps.service.Name())
+		require.False(t, ok)
+	})
+
+	t.Run("domain removed", func(t *testing.T) {
+		deps := createDeps(t, true)
+		require.NoError(t, deps.cache.Update(core.NewServiceStatusUpdate(serviceStatus(deps.service.Name(), domainLoad(deps.domain.Name()))), false))
+		_, ok := deps.cache.ServiceStatus(deps.service.Name())
+		require.True(t, ok)
+
+		serviceInfo := model.NewServiceInfo(deps.service, deps.serviceInfo.Version()+1, time.Now())
+		require.NoError(t, deps.cache.Update(core.NewDomainRemoval(serviceInfo, deps.domain.Name()), false))
+
+		status, ok := deps.cache.ServiceStatus(deps.service.Name())
+		require.True(t, ok)
+		require.True(t, serviceLoadHasDomain(status.Load(), deps.domain.Name()))
+
+		snap := deps.cache.Snapshot()
+		require.NotEmpty(t, snap.Tenants()[0].Statuses())
+	})
+}
+
+type cacheTestDeps struct {
+	cache       *Cache
+	tenant      model.Tenant
+	service     model.Service
+	serviceInfo model.ServiceInfo
+	domain      model.Domain
+}
+
+func createDeps(t *testing.T, trackLoad bool) cacheTestDeps {
+	t.Helper()
+
+	cache := NewCache()
+
+	tenant, err := model.NewTenant(tenantName, time.Now())
+	require.NoError(t, err)
+
+	cfg := model.NewServiceConfig(model.WithTrackLoad(trackLoad))
+	service, err := model.NewService(qsn, time.Now(), model.WithServiceConfig(cfg))
+	require.NoError(t, err)
+
+	qdn := model.QualifiedDomainName{Service: service.Name(), Domain: model.DomainName("domain1")}
+	domain, err := model.NewDomain(qdn, model.Unit, time.Now())
+	require.NoError(t, err)
+
+	// update tenant, service and domains.
+	require.NoError(t, cache.Update(core.NewTenantUpdate(model.NewTenantInfo(tenant, 1, time.Now())), false))
+	serviceInfo := model.NewServiceInfo(service, 1, time.Now())
+	require.NoError(t, cache.Update(core.NewDomainUpdate(serviceInfo, domain), false))
+
+	return cacheTestDeps{
+		cache:       cache,
+		tenant:      tenant,
+		service:     service,
+		serviceInfo: serviceInfo,
+		domain:      domain,
+	}
+}
+
+func serviceStatus(qsn model.QualifiedServiceName, loads ...core.DomainLoadInfo) core.ServiceStatus {
+	serviceLoad := core.NewServiceLoadInfo(qsn, loads)
+	status := core.NewServiceStatus(serviceLoad)
+	return status
+}
+
+func domainLoad(domain model.QualifiedDomainName) core.DomainLoadInfo {
+	snap := core.NewP2QuantileSnapshot(
+		0.5,
+		[]float64{10, 10, 10, 10, 10},
+		[]uint64{1, 2, 3, 4, 10},
+		[]float64{1, 2, 3, 4, 10},
+	)
+	trackers := core.NewDomainTrackerSnapshot(time.Now(), snap, nil)
+	return core.NewDomainLoadInfo(domain.Domain, trackers, nil)
+}
+
+func serviceLoadHasDomain(load core.ServiceLoadInfo, domain model.QualifiedDomainName) bool {
+	if load.Service() != domain.Service {
+		return false
+	}
+	for _, domainLoad := range load.Domains() {
+		if domainLoad.DomainName() == domain.Domain {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/storage/raft/BUILD.bazel
+++ b/pkg/storage/raft/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "raft",
@@ -17,5 +17,20 @@ go_library(
         "@co_atoms_go_lib//log",
         "@co_atoms_go_lib//metrics",
         "@com_github_hashicorp_raft//:raft",
+    ],
+)
+
+go_test(
+    name = "raft_test",
+    srcs = glob(["*_test.go"]),
+    embed = [":raft"],
+    deps = [
+        "//pkg/core",
+        "//pkg/model",
+        "//proto/atoms/splitter/private:private_go_proto",
+        "//testing/prefab",
+        "@co_atoms_go_lib//encoding/protox",
+        "@com_github_hashicorp_raft//:raft",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/storage/raft/fsm_test.go
+++ b/pkg/storage/raft/fsm_test.go
@@ -1,0 +1,134 @@
+package raft
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	hashicorpraft "github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+
+	"go.atoms.co/lib/encoding/protox"
+	splitterprivatepb "go.atoms.co/splitter/pb/private"
+	"go.atoms.co/splitter/pkg/core"
+	"go.atoms.co/splitter/pkg/model"
+	"go.atoms.co/splitter/testing/prefab"
+)
+
+func TestStorage_UpdateServiceStatusThroughRaft(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		now := time.Now()
+		db, logStore, cleanup := newRaftStorage(t)
+		defer cleanup()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// setup tenant, service and domain
+		serviceName := model.QualifiedServiceName{
+			Tenant:  model.TenantName("tenant"),
+			Service: model.ServiceName("service"),
+		}
+		domainName := prefab.QDN("tenant/service/domain")
+
+		tenant, err := model.NewTenant(serviceName.Tenant, now)
+		require.NoError(t, err)
+		require.NoError(t, db.Update(ctx, core.NewTenantUpdate(model.NewTenantInfo(tenant, 1, now))))
+
+		serviceCfg := model.NewServiceConfig(model.WithTrackLoad(true))
+		service, err := model.NewService(serviceName, now, model.WithServiceConfig(serviceCfg))
+		require.NoError(t, err)
+		serviceInfo := model.NewServiceInfo(service, 1, now)
+		require.NoError(t, db.Update(ctx, core.NewServiceUpdate(serviceInfo)))
+
+		domain, err := model.NewDomain(domainName, model.Unit, now)
+		require.NoError(t, err)
+		serviceInfo = model.NewServiceInfo(service, 2, now)
+		require.NoError(t, db.Update(ctx, core.NewDomainUpdate(serviceInfo, domain)))
+
+		// store ServiceStatus
+		snap := core.NewP2QuantileSnapshot(
+			0.5,
+			[]float64{10, 10, 10, 10, 10},
+			[]uint64{1, 2, 3, 4, 10},
+			[]float64{1, 2, 3, 4, 10},
+		)
+		tracker := core.NewDomainTrackerSnapshot(now, snap, nil)
+		domainLoadInfo := core.NewDomainLoadInfo(domainName.Domain, tracker, nil)
+		status := core.NewServiceStatus(core.NewServiceLoadInfo(serviceName, []core.DomainLoadInfo{
+			domainLoadInfo,
+		}))
+		require.NoError(t, db.Update(ctx, core.NewServiceStatusUpdate(status)))
+
+		// require ServiceStatus in raft log
+		lastIndex, err := logStore.LastIndex()
+		require.NoError(t, err)
+
+		var entry hashicorpraft.Log
+		require.NoError(t, logStore.GetLog(lastIndex, &entry))
+
+		mutation, err := protox.Unmarshal[splitterprivatepb.Mutation](entry.Data)
+		require.NoError(t, err)
+		require.NotNil(t, mutation.GetUpdate())
+
+		actual, ok := core.WrapUpdate(mutation.GetUpdate()).ServiceStatus()
+		require.True(t, ok)
+		require.True(t, status.Equal(actual))
+
+		// require ServiceStatus in snapshot
+		snapshot, err := db.Read(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, snapshot.Tenants(), 1)
+		require.Len(t, snapshot.Tenants()[0].Statuses(), 1)
+		require.True(t, status.Equal(snapshot.Tenants()[0].Statuses()[0]))
+	})
+}
+
+func newRaftStorage(t *testing.T) (*Storage, *hashicorpraft.InmemStore, func()) {
+	t.Helper()
+
+	const serverID = hashicorpraft.ServerID("node1")
+
+	cfg := hashicorpraft.DefaultConfig()
+	cfg.LocalID = serverID
+
+	fsm := NewFSM()
+	logStore := hashicorpraft.NewInmemStore()
+	stableStore := hashicorpraft.NewInmemStore()
+	snapshotStore := hashicorpraft.NewInmemSnapshotStore()
+	addr, transport := hashicorpraft.NewInmemTransport(hashicorpraft.NewInmemAddr())
+
+	r, err := hashicorpraft.NewRaft(cfg, fsm, logStore, stableStore, snapshotStore, transport)
+	require.NoError(t, err)
+
+	require.NoError(t, r.BootstrapCluster(hashicorpraft.Configuration{
+		Servers: []hashicorpraft.Server{{
+			ID:      serverID,
+			Address: addr,
+		}},
+	}).Error())
+
+	// A node has state transition Follower -> Candidate -> Leader before becoming the leader.
+	// Wait leader election to finish.
+	for range 50 {
+		synctest.Wait()
+		_, leaderID := r.LeaderWithID()
+		if r.State() == hashicorpraft.Leader && leaderID == serverID {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	require.Equal(t, hashicorpraft.Leader, r.State())
+	_, leaderID := r.LeaderWithID()
+	require.Equal(t, serverID, leaderID)
+
+	cleanup := func() {
+		require.NoError(t, r.Shutdown().Error())
+		require.NoError(t, transport.Close())
+	}
+
+	return New(serverID, r, fsm), logStore, cleanup
+}

--- a/proto/atoms/splitter/private/state.proto
+++ b/proto/atoms/splitter/private/state.proto
@@ -5,6 +5,7 @@ package atoms.splitter.private;
 import "atoms/splitter/model.proto";
 import "atoms/splitter/management.proto";
 import "atoms/splitter/placement.proto";
+import "atoms/splitter/private/load.proto";
 import "atoms/splitter/private/placement.proto";
 
 option go_package = "go.atoms.co/splitter/pb/private";
@@ -14,12 +15,18 @@ message State {
   atoms.splitter.TenantInfo tenant = 1;
   repeated atoms.splitter.ServiceInfoEx services = 2;
   repeated InternalPlacementInfo placements = 3;
+  repeated ServiceStatus statuses = 4;
 }
 
 message ServiceUpdate {
   atoms.splitter.ServiceInfo service = 1;
   repeated atoms.splitter.Domain updated = 2;
   repeated atoms.splitter.QualifiedDomainName removed = 3;
+}
+
+// ServiceStatus represents status of a service.
+message ServiceStatus {
+  ServiceLoadInfo load = 1;
 }
 
 // Update is an incremental update to a single tenant. Updates to multiple aspects can be made
@@ -43,6 +50,7 @@ message Update {
   Tenant tenant = 2;
   Service service = 3;
   Placement placement = 4;
+  ServiceStatus status = 5;
 }
 
 // Delete removes an entire tenant.


### PR DESCRIPTION
This change:
- Process ServiceStatus message from coordinator.
- Persist ServiceStatus raft storage