### PR TITLE
Reject stale domain updates

### DIFF
--- a/pkg/service/leader/leader_test.go
+++ b/pkg/service/leader/leader_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.atoms.co/lib/chanx"
+	"go.atoms.co/lib/testing/assertx"
 	"go.atoms.co/splitter/lib/service/location"
 	"go.atoms.co/splitter/lib/service/session"
-	"go.atoms.co/lib/testing/assertx"
+	splitterpb "go.atoms.co/splitter/pb"
+	splitterprivatepb "go.atoms.co/splitter/pb/private"
 	"go.atoms.co/splitter/pkg/core"
 	"go.atoms.co/splitter/pkg/model"
 	"go.atoms.co/splitter/pkg/service/leader"
 	"go.atoms.co/splitter/pkg/storage"
 	"go.atoms.co/splitter/pkg/storage/memory"
-	splitterprivatepb "go.atoms.co/splitter/pb/private"
-	splitterpb "go.atoms.co/splitter/pb"
-	"go.atoms.co/lib/chanx"
 )
 
 const (
@@ -265,6 +265,64 @@ func TestLeader_HandleUpdate(t *testing.T) {
 		assert.Equal(t, service.Name(), update.Grant().Service())
 		assert.True(t, update.State().IsStateUpdated())
 	})
+}
+
+func TestLeader_UpdateDomainRejectsStaleServiceVersion(t *testing.T) {
+	ctx := context.Background()
+	loc := location.New("centralus", "splitter-0")
+
+	service, err := model.NewService(s1, time.Now(), model.WithServiceConfig(model.NewServiceConfig(model.WithServiceRegion("centralus"))))
+	require.NoError(t, err)
+
+	qdn := model.QualifiedDomainName{Service: service.Name(), Domain: model.DomainName("domain")}
+	domain, err := model.NewDomain(qdn, model.Regional, time.Now(), model.WithDomainConfig(model.NewDomainConfig(model.WithDomainRegions("centralus"), model.WithDomainShardingPolicy(model.NewShardingPolicy(1)))))
+	require.NoError(t, err)
+
+	db := setupWithDomains(t, ctx, service, domain)
+	l := leader.New(ctx, loc, db, leader.WithFastActivation())
+	defer l.Close()
+	<-l.Initialized().Closed()
+
+	updateDomain := func(version model.Version, config model.DomainConfig) (*splitterpb.UpdateDomainResponse, error) {
+		resp, err := l.Handle(ctx, leader.NewHandleDomainRequest(&splitterprivatepb.DomainRequest{
+			Req: &splitterprivatepb.DomainRequest_Update{
+				Update: &splitterpb.UpdateDomainRequest{
+					Name:           qdn.ToProto(),
+					ServiceVersion: int64(version),
+					Config:         model.UnwrapDomainConfig(config),
+				},
+			},
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return resp.GetDomain().GetUpdate(), nil
+	}
+
+	const serviceVersion model.Version = 2
+
+	firstConfig, err := model.UpdateDomainConfig(domain, model.WithDomainShardingPolicy(model.NewShardingPolicy(2)))
+	require.NoError(t, err)
+	firstUpdate, err := updateDomain(serviceVersion, firstConfig)
+	require.NoError(t, err)
+	assert.Equal(t, 2, model.WrapDomain(firstUpdate.GetDomain()).Config().ShardingPolicy().Shards())
+
+	staleConfig, err := model.UpdateDomainConfig(domain, model.WithDomainRegions("centralus", "eastus2"))
+	require.NoError(t, err)
+	_, err = updateDomain(serviceVersion, staleConfig)
+	require.ErrorIs(t, err, model.ErrVersionMismatch)
+
+	resp, err := l.Handle(ctx, leader.NewHandleDomainRequest(&splitterprivatepb.DomainRequest{
+		Req: &splitterprivatepb.DomainRequest_List{
+			List: &splitterpb.ListDomainsRequest{Service: service.Name().ToProto()},
+		},
+	}))
+	require.NoError(t, err)
+	domains := resp.GetDomain().GetList().GetDomains()
+	require.Len(t, domains, 1)
+	current := model.WrapDomain(domains[0])
+	assert.Equal(t, 2, current.Config().ShardingPolicy().Shards())
+	assert.Equal(t, []model.Region{"centralus"}, current.Regions())
 }
 
 func setup(t *testing.T, ctx context.Context, services ...model.Service) storage.Storage {

--- a/pkg/service/leader/writer.go
+++ b/pkg/service/leader/writer.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"time"
 
-	"go.atoms.co/lib/log"
 	"go.atoms.co/iox"
+	"go.atoms.co/lib/log"
 	"go.atoms.co/lib/workqueue"
+	splitterpb "go.atoms.co/splitter/pb"
+	splitterprivatepb "go.atoms.co/splitter/pb/private"
 	"go.atoms.co/splitter/pkg/core"
 	"go.atoms.co/splitter/pkg/model"
 	"go.atoms.co/splitter/pkg/storage"
-	splitterprivatepb "go.atoms.co/splitter/pb/private"
-	splitterpb "go.atoms.co/splitter/pb"
 )
 
 const (
@@ -386,7 +386,7 @@ func (w *Writer) handleUpdateDomainRequest(ctx context.Context, req *splitterpb.
 	if !ok {
 		return nil, nil, fmt.Errorf("service %v not found: %w", name, model.ErrNotFound)
 	}
-	guard := service.Info().Version()
+	guard := model.Version(req.GetServiceVersion())
 
 	existing, ok := service.Domain(name.Domain)
 	if !ok {


### PR DESCRIPTION
Use the client-provided service version when updating domains and reject stale updates to prevent silently overwriting newer configuration