### PR TITLE
 Close remote leader connections on leadership changes

### DIFF
--- a/pkg/service/leader/BUILD.bazel
+++ b/pkg/service/leader/BUILD.bazel
@@ -53,5 +53,7 @@ go_test(
         "@co_atoms_go_lib//testing/assertx",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//stats",
     ],
 )

--- a/pkg/service/leader/manager.go
+++ b/pkg/service/leader/manager.go
@@ -6,13 +6,13 @@ import (
 	"sync"
 	"time"
 
-	"go.atoms.co/splitter/lib/service/session"
-	"go.atoms.co/lib/log"
-	"go.atoms.co/lib/contextx"
-	"go.atoms.co/lib/net/grpcx"
 	"go.atoms.co/iox"
-	"go.atoms.co/splitter/pkg/model"
+	"go.atoms.co/lib/contextx"
+	"go.atoms.co/lib/log"
+	"go.atoms.co/lib/net/grpcx"
+	"go.atoms.co/splitter/lib/service/session"
 	splitterprivatepb "go.atoms.co/splitter/pb/private"
+	"go.atoms.co/splitter/pkg/model"
 )
 
 type DirectiveType string
@@ -62,8 +62,8 @@ type ResolvingManager struct {
 	factory Factory
 
 	remote splitterprivatepb.LeaderServiceClient // nil if local
-	local  Proxy                              // nil if remote
-	halt   iox.AsyncCloser                    // stop signal for local/remote re-creation if active
+	local  Proxy                                 // nil if remote
+	halt   iox.AsyncCloser                       // stop signal for local/remote re-creation if active
 	mu     sync.Mutex
 
 	drain iox.AsyncCloser
@@ -200,6 +200,7 @@ func (m *ResolvingManager) follow(ctx context.Context, halt iox.AsyncCloser, id,
 			time.Sleep(4 * time.Second)
 			continue
 		}
+		defer cc.Close()
 
 		log.Infof(ctx, "Connected to remote leader %v @%v", id, endpoint)
 

--- a/pkg/service/leader/manager_test.go
+++ b/pkg/service/leader/manager_test.go
@@ -1,0 +1,79 @@
+package leader_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/stats"
+
+	"go.atoms.co/splitter/pkg/service/leader"
+)
+
+func TestManagerClosesRemoteConnectionOnLeadershipChange(t *testing.T) {
+	connections := &connectionStats{
+		started: make(chan struct{}, 1),
+		ended:   make(chan struct{}, 1),
+	}
+	server := grpc.NewServer(grpc.StatsHandler(connections))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	defer server.Stop()
+
+	directives := make(chan leader.Directive)
+	manager := leader.NewManager(directives, nil)
+	defer func() {
+		close(directives)
+		<-manager.Closed()
+	}()
+
+	directives <- leader.Directive{Type: leader.Follow, ID: "leader1", Endpoint: listener.Addr().String()}
+	select {
+	case <-connections.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("manager did not connect to remote leader")
+	}
+
+	directives <- leader.Directive{Type: leader.Disconnect}
+	select {
+	case <-connections.ended:
+	case <-time.After(5 * time.Second):
+		t.Fatal("manager did not close remote leader connection")
+	}
+}
+
+type connectionStats struct {
+	started chan struct{}
+	ended   chan struct{}
+}
+
+func (s *connectionStats) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (s *connectionStats) HandleRPC(context.Context, stats.RPCStats) {}
+
+func (s *connectionStats) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (s *connectionStats) HandleConn(_ context.Context, event stats.ConnStats) {
+	switch event.(type) {
+	case *stats.ConnBegin:
+		select {
+		case s.started <- struct{}{}:
+		default:
+		}
+	case *stats.ConnEnd:
+		select {
+		case s.ended <- struct{}{}:
+		default:
+		}
+	}
+}


### PR DESCRIPTION
Close the gRPC ClientConn owned by each follower lifecycle on leadership changes.