### PR TITLE
Update default shard load

### DIFF
--- a/pkg/service/coordinator/allocation.go
+++ b/pkg/service/coordinator/allocation.go
@@ -19,11 +19,11 @@ import (
 )
 
 const (
-	baseShardLoad      allocation.Load = 10
-	unitShardLoad      allocation.Load = 50
-	regionAffinityLoad allocation.Load = 20
-	namedShardsLoad    allocation.Load = 20
-	antiAffinityLoad   allocation.Load = 20
+	defaultShardLoad   = allocation.Load(50)
+	unitShardLoad      = defaultShardLoad * 5
+	regionAffinityLoad = defaultShardLoad * 2
+	namedShardsLoad    = defaultShardLoad * 2
+	antiAffinityLoad   = defaultShardLoad * 2
 )
 
 type (
@@ -301,7 +301,7 @@ func findWork(state model.ServiceInfoEx, placements []core.InternalPlacementInfo
 							To:     model.Key(shard.To()),
 						},
 						Data: slicex.New(location.Location{Region: region}),
-						Load: baseShardLoad,
+						Load: defaultShardLoad,
 					}
 					ret = append(ret, w)
 				}
@@ -320,7 +320,7 @@ func findWork(state model.ServiceInfoEx, placements []core.InternalPlacementInfo
 							To:     model.Key(shard.To()),
 						},
 						Data: locations,
-						Load: baseShardLoad,
+						Load: defaultShardLoad,
 					}
 					ret = append(ret, w)
 				}
@@ -340,7 +340,7 @@ func findWork(state model.ServiceInfoEx, placements []core.InternalPlacementInfo
 							To:     model.Key(shard.To()),
 						},
 						Data: slicex.New(location.Location{Region: region}),
-						Load: baseShardLoad,
+						Load: defaultShardLoad,
 					})
 				}
 			}

--- a/pkg/service/coordinator/coordinator.go
+++ b/pkg/service/coordinator/coordinator.go
@@ -393,7 +393,7 @@ func (c *coordinator) connect(ctx context.Context, sid session.ID, origin locati
 	lease := now.Add(leaseDuration)
 	s.TrySend(ctx, model.NewExtend(lease)) // grants will be covered under this lease
 
-	capacity := allocation.Load(int64(limit) * int64(baseShardLoad)) // Set capacity shard limit * shard load (0 for no capacity)
+	capacity := allocation.Load(int64(limit) * int64(defaultShardLoad)) // Set capacity shard limit * shard load (0 for no capacity)
 	if capacity > 0 {
 		log.Infof(ctx, "Consumer %v connected with non-zero capacity limit: %v", consumer, capacity)
 	}


### PR DESCRIPTION
Set the default shard load to the median load-aware allocation score and define related loads and penalties relative to that default.
