### PR TITLE
Recompute colocation after moving grants

### DIFF
--- a/pkg/allocation/allocation.go
+++ b/pkg/allocation/allocation.go
@@ -2,13 +2,14 @@ package allocation
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
-	"go.atoms.co/splitter/lib/service/location"
 	"go.atoms.co/lib/container"
 	"go.atoms.co/lib/mapx"
 	"go.atoms.co/lib/mathx"
+	
 )
 
 const (
@@ -926,6 +927,7 @@ func (a *Allocation[T, W, K, V]) move(from *worker[T, W, K, V], grant live[T, W]
 	allocated := NewGrant(a.newGrantID(), Allocated, None, work.Unit, to.info.Instance.ID, now, to.info.Lease)
 	if a.tryAssign(to, allocated) {
 		delete(a.unassigned, work.Unit)
+		to.load.Colo, to.colo = a.colo.Colocate(to.info.Instance, to.Live())
 	}
 	return Move[T, K]{From: revoked, To: allocated}
 }
@@ -1050,6 +1052,11 @@ func (a *Allocation[T, W, K, V]) Check() error {
 		}
 		if load != w.load {
 			return fmt.Errorf("inconsistent load for %v: %v <> %v", w.info, w.load, load)
+		}
+
+		colo, colocations := a.colo.Colocate(w.info.Instance, w.Live())
+		if colo != w.load.Colo || !maps.Equal(colocations, w.colo) {
+			return fmt.Errorf("inconsistent colocation for %v: %v@%v <> %v@%v", w.info, w.load.Colo, w.colo, colo, colocations)
 		}
 	}
 

--- a/pkg/allocation/allocation.go
+++ b/pkg/allocation/allocation.go
@@ -9,7 +9,7 @@ import (
 	"go.atoms.co/lib/container"
 	"go.atoms.co/lib/mapx"
 	"go.atoms.co/lib/mathx"
-	
+	"go.atoms.co/splitter/lib/service/location"
 )
 
 const (

--- a/pkg/allocation/allocation_test.go
+++ b/pkg/allocation/allocation_test.go
@@ -49,6 +49,25 @@ func (r regionBan) TryPlace(worker allocation.Worker[string, location.Location],
 	return 0, true
 }
 
+type pairColocation struct {
+	first, second string
+	penalty       allocation.Load
+}
+
+func (p pairColocation) ID() allocation.Rule {
+	return "pair-colocation"
+}
+
+func (p pairColocation) Colocate(_ allocation.Worker[string, location.Location], work map[string]allocation.Work[string, location.Location]) map[string]allocation.Load {
+	if _, ok := work[p.first]; !ok {
+		return nil
+	}
+	if _, ok := work[p.second]; !ok {
+		return nil
+	}
+	return map[string]allocation.Load{p.first: p.penalty}
+}
+
 func TestAllocation(t *testing.T) {
 	work := []allocation.Work[string, location.Location]{
 		{Unit: "a", Load: 20, Data: us},
@@ -772,6 +791,40 @@ func TestAllocation(t *testing.T) {
 		require.True(t, ok)
 		assert.Subset(t, intrinsicLoads(loads, "w1", "w2", "w3"), []allocation.Load{50, 10, 10})
 
+		require.NoError(t, alloc.Check())
+	})
+
+	synctestx.Run(t, "load-balance/colocation", func(t *testing.T) {
+		work := []allocation.Work[string, location.Location]{
+			{Unit: "a", Load: 10, Data: eu},
+			{Unit: "b", Load: 10, Data: eu},
+		}
+		region := allocation.NewPreference("region-affinity", 50, hasRegionAffinity)
+		colocation := pairColocation{first: "a", second: "b", penalty: 20}
+		alloc := allocation.New[string, location.Location, string, location.Location]("id", []allocation.Placement[string, location.Location, string, location.Location]{region}, []allocation.Colocation[string, location.Location, string, location.Location]{colocation}, work, time.Now())
+
+		now := time.Now()
+		lease := now.Add(time.Minute)
+		source := allocation.Worker[string, location.Location]{ID: "source", Data: us}
+		destination := allocation.Worker[string, location.Location]{ID: "destination", Data: eu}
+		sourceGrant := allocation.NewGrant[string, string]("source-a", allocation.Active, allocation.None, "a", source.ID, now, lease)
+		destinationGrant := allocation.NewGrant[string, string]("destination-b", allocation.Active, allocation.None, "b", destination.ID, now, lease)
+
+		_, ok := alloc.Attach(source, allocation.NoCapacityLimit, lease, sourceGrant)
+		require.True(t, ok)
+		_, ok = alloc.Attach(destination, allocation.NoCapacityLimit, lease, destinationGrant)
+		require.True(t, ok)
+
+		move, diff, ok := alloc.LoadBalance(now, nil)
+		require.True(t, ok)
+		require.Equal(t, "a", move.From.Unit)
+		require.Equal(t, source.ID, move.From.Worker)
+		require.Equal(t, destination.ID, move.To.Worker)
+		require.Equal(t, allocation.AdjustedLoad{Place: -50, Colo: 20}, diff)
+
+		load, ok := alloc.LoadByWorker(destination.ID)
+		require.True(t, ok)
+		require.Equal(t, allocation.AdjustedLoad{Load: 20, Colo: 20}, load)
 		require.NoError(t, alloc.Check())
 	})
 

--- a/pkg/service/coordinator/coordinator_test.go
+++ b/pkg/service/coordinator/coordinator_test.go
@@ -525,6 +525,55 @@ func TestCoordinator_NamedKeyDisconnectDropsNamedShardPenalty(t *testing.T) {
 	})
 }
 
+func TestCoordinator_AntiAffinityColocation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+
+		domainA, err := model.NewDomain(domainName, model.Global, time.Now(), model.WithDomainConfig(model.NewDomainConfig(model.WithDomainShardingPolicy(model.NewShardingPolicy(1)), model.WithDomainAntiAffinity(domain2))))
+		require.NoError(t, err)
+		domainB, err := model.NewDomain(domainName2, model.Global, time.Now(), model.WithDomainConfig(model.NewDomainConfig(model.WithDomainShardingPolicy(model.NewShardingPolicy(1)))))
+		require.NoError(t, err)
+
+		coord, _ := setup(ctx, t, []model.Domain{domainA, domainB}, WithFastActivation())
+		c := coord.(*coordinator)
+
+		consumer := model.NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
+		in := make(chan model.ConsumerMessage, 1)
+		in <- newRegister(consumer, serviceName, nil, nil)
+		out, err := coord.Connect(ctx, session.NewID(), location.NewInstance(location.New("centralus", "splitter1")), in)
+		require.NoError(t, err, "consumer failed to join coordinator")
+		defer func() {
+			coord.Close()
+			assertx.Closed(t, out)
+		}()
+
+		readFn(t, out, isClusterSnapshot)
+		for range 2 {
+			assign := readFn(t, out, isAssign)
+			require.Len(t, assign.Grants(), 1)
+		}
+
+		assigned := c.alloc.Assigned(consumer.ID()).All()
+		require.Len(t, assigned, 2)
+		var shardA, shardB model.Shard
+		for _, grant := range assigned {
+			switch grant.Unit.Domain {
+			case domainName:
+				shardA = grant.Unit
+			case domainName2:
+				shardB = grant.Unit
+			}
+		}
+		require.Equal(t, domainName, shardA.Domain)
+		require.Equal(t, domainName2, shardB.Domain)
+		require.True(t, shardA.IntersectsRange(shardB))
+
+		load, ok := c.alloc.LoadByWorker(consumer.ID())
+		require.True(t, ok)
+		assert.Equal(t, antiAffinityLoad, load.Colo)
+	})
+}
+
 func TestCoordinator_RevokeGrant(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 


### PR DESCRIPTION
Refresh destination colocation after load balancing moves.