### PR TITLE
Add structured logs on attach

### DIFF
--- a/pkg/model/grantlogging.go
+++ b/pkg/model/grantlogging.go
@@ -11,7 +11,7 @@ import (
 	"go.atoms.co/lib/mapx"
 )
 
-// GrantEventType identifies the transition of a grant (by an event). Used in logging of grant events.
+// GrantEventType identifies an event in structured grant logging.
 type GrantEventType string
 
 type grantLogSource string
@@ -31,8 +31,12 @@ const (
 	GrantExpired GrantEventType = "expire"
 	// GrantRemoved records a grant removed from a consumer.
 	GrantRemoved GrantEventType = "remove"
+	// GrantAttached records a grant accepted from a reconnecting consumer.
+	GrantAttached GrantEventType = "attach"
 	// GrantCheckpoint records current grants grouped by shard.
 	GrantCheckpoint GrantEventType = "checkpoint"
+	// CoordinatorStarted records the beginning of a coordinator allocation epoch.
+	CoordinatorStarted GrantEventType = "coordinator_start"
 
 	grantLogSourceCoordinator grantLogSource = "coordinator"
 	grantLogSourceConsumer    grantLogSource = "consumer"
@@ -76,7 +80,7 @@ func grantEventFields(event grantEvent) []log.Field {
 	if event.eventType != "" {
 		fields = append(fields, log.String("event_type", string(event.eventType)))
 	}
-	if event.eventType == GrantCheckpoint {
+	if event.eventType == GrantCheckpoint || event.eventType == CoordinatorStarted {
 		return fields
 	}
 	fields = append(fields, log.String("domain", string(event.shard.Domain.Domain)), log.String("shard_region", string(event.shard.Region)))
@@ -94,6 +98,11 @@ func grantEventFields(event grantEvent) []log.Field {
 func logGrantEvent(ctx context.Context, severity log.Severity, message string, event grantEvent, calldepth int, fields ...log.Field) {
 	fields = append(grantEventFields(event), fields...)
 	log.Output(log.NewContext(ctx, fields...), severity, calldepth, message)
+}
+
+// LogCoordinatorStarted records the beginning of a coordinator allocation epoch.
+func LogCoordinatorStarted(ctx context.Context, severity log.Severity, message string) {
+	logGrantEvent(ctx, severity, message, grantEvent{source: grantLogSourceCoordinator, eventType: CoordinatorStarted}, 3)
 }
 
 // LogCoordinatorGrantEvent emits structured fields for a coordinator grant event.

--- a/pkg/service/coordinator/coordinator.go
+++ b/pkg/service/coordinator/coordinator.go
@@ -398,6 +398,9 @@ func (c *coordinator) connect(ctx context.Context, sid session.ID, origin locati
 	}
 
 	if assigned, ok := c.alloc.Attach(allocation.NewWorker(consumer.instance.ID(), consumer), capacity, lease, active...); ok {
+		for _, grant := range slices.Concat(assigned.Active, assigned.Allocated) {
+			logGrantEvent(ctx, log.SevInfo, "Grant attached", grant, model.GrantAttached, nil, toGrantState(grant.State, grant.Mod).Enum(), s)
+		}
 		if len(assigned.Active) > 0 {
 			s.TrySend(ctx, model.NewAssign(slicex.Map(assigned.Active, toGrant)...))
 		}
@@ -548,6 +551,7 @@ func (c *coordinator) init(ctx context.Context, state core.State, updates <-chan
 	c.noLb = c.findUnitDomains()
 	c.cluster = model.NewClusterMap(model.NewClusterID(c.self, now), c.alloc.Units())
 
+	model.LogCoordinatorStarted(ctx, log.SevInfo, "Coordinator started")
 	log.Infof(ctx, "Coordinator %v/%v initialized, #shards=%v", c.name, c.self, c.alloc.Size())
 	c.recordAction(ctx, "init", "ok")
 	c.recordActionLatency(ctx, "init", start)


### PR DESCRIPTION
Adds logging on attach and coordinator start so shard tracker can properly handle switching coordinators.