### PR TITLE
Add support for clients to report load to the coordinator

### DIFF
--- a/pkg/model/client.go
+++ b/pkg/model/client.go
@@ -25,7 +25,7 @@ var (
 	ErrExpired = errors.New("grant expired")
 
 	// ClientVersion of the client library.
-	ClientVersion = "1.2.0"
+	ClientVersion = "1.2.1"
 )
 
 // Ownership holds information about the grant state and expiration, as well as signals for
@@ -79,6 +79,9 @@ type Ownership interface {
 	// normal circumstances. When the expiration time is past the current moment the grant is no longer assigned
 	// to the current consumer and the consumer must abort processing immediately.
 	Expiration() time.Time
+
+	// Reporter returns StatusReporter used by Range to report status to coordinator.
+	Reporter() StatusReporter
 }
 
 // Loader is used during the loading phase of a grant to coordinate transfer of ownership. It
@@ -100,6 +103,12 @@ type Unloader interface {
 	// Loaded returns a closer for when the counterpart transitions to Loaded, usually in response to
 	// the Unload signal. It may never happen.
 	Loaded() iox.RAsyncCloser
+}
+
+// StatusReporter provides a bridge between Range and workpool to report grant-scoped status to the coordinator.
+type StatusReporter interface {
+	// ReportLoad reports load
+	ReportLoad(load Load) error
 }
 
 // WaitForUnload blocks on prior counterpart Grant unloading. Typically, this signals that the handler

--- a/pkg/model/client_test.go
+++ b/pkg/model/client_test.go
@@ -100,6 +100,42 @@ func TestClient_WaitForRevoke(t *testing.T) {
 	})
 }
 
+func TestOwnershipReporter(t *testing.T) {
+	t.Run("reports load", func(t *testing.T) {
+		ownership := newOwnership(ActiveGrantState, func() time.Time {
+			return time.Now().Add(time.Minute)
+		}, newLoader(), newUnloader())
+		defer ownership.reporter.Close()
+		reporter := ownership.Reporter()
+
+		assert.NoError(t, reporter.ReportLoad(42))
+		assert.Equal(t, Load(42), <-ownership.reporter.loads())
+	})
+
+	t.Run("rejects load when full", func(t *testing.T) {
+		ownership := newOwnership(ActiveGrantState, func() time.Time {
+			return time.Now().Add(time.Minute)
+		}, newLoader(), newUnloader())
+		defer ownership.reporter.Close()
+		reporter := ownership.Reporter()
+
+		for range cap(ownership.reporter.loads()) {
+			assert.NoError(t, reporter.ReportLoad(1))
+		}
+		assert.ErrorIs(t, errBufferFull, reporter.ReportLoad(1))
+	})
+
+	t.Run("closes reporter", func(t *testing.T) {
+		ownership := newOwnership(ActiveGrantState, func() time.Time {
+			return time.Now().Add(time.Minute)
+		}, newLoader(), newUnloader())
+		reporter := ownership.Reporter()
+		ownership.reporter.Close()
+
+		assert.ErrorIs(t, errReporterClosed, reporter.ReportLoad(1))
+	})
+}
+
 type testOwnership struct {
 	active          iox.AsyncCloser
 	revoked         iox.AsyncCloser
@@ -107,6 +143,7 @@ type testOwnership struct {
 	expired         iox.AsyncCloser
 	loader          *loader
 	unloader        *unloader
+	reporter        StatusReporter
 }
 
 func newTestOwnership() *testOwnership {
@@ -123,6 +160,7 @@ func newTestOwnership() *testOwnership {
 			loaded: iox.NewAsyncCloser(),
 			unload: iox.NewAsyncCloser(),
 		},
+		reporter: newStatusReporter(),
 	}
 }
 
@@ -176,4 +214,8 @@ func (t *testOwnership) IsExpired() bool {
 
 func (t *testOwnership) Expiration() time.Time {
 	return time.Time{}
+}
+
+func (t *testOwnership) Reporter() StatusReporter {
+	return t.reporter
 }

--- a/pkg/model/grant.go
+++ b/pkg/model/grant.go
@@ -2,11 +2,12 @@ package model
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
-	"go.atoms.co/lib/timex"
 	"go.atoms.co/iox"
+	"go.atoms.co/lib/timex"
 )
 
 // LeaseState represents the current state of a grant.
@@ -20,6 +21,11 @@ const (
 	// LeaseStale represents that the grant is active, but will lapse due to a coordinator disconnect. Most
 	// grants will go back to active, but that is the coordinator's decision.
 	LeaseStale LeaseState = "stale"
+)
+
+var (
+	errReporterClosed = errors.New("reporter closed")
+	errBufferFull     = errors.New("buffer full")
 )
 
 // grant holds a grant and its metadata and bookkeeping.
@@ -70,6 +76,7 @@ func newHandler(ctx context.Context, grant Grant, expiration func() time.Time, l
 
 		cancel()
 		h.ownership.expire()
+		h.ownership.reporter.Close()
 	}()
 
 	return h
@@ -91,6 +98,7 @@ type ownership struct {
 	loader          *loader
 	unloader        *unloader
 	expiration      func() time.Time
+	reporter        *statusReporter
 }
 
 func newOwnership(state GrantState, expiration func() time.Time, loader *loader, unloader *unloader) *ownership {
@@ -102,6 +110,7 @@ func newOwnership(state GrantState, expiration func() time.Time, loader *loader,
 		loader:          loader,
 		unloader:        unloader,
 		expiration:      expiration,
+		reporter:        newStatusReporter(),
 	}
 
 	// Initialize correct signals using GrantState
@@ -159,6 +168,10 @@ func (o *ownership) RequestRevoke() {
 	o.revokeRequested.Close()
 }
 
+func (o *ownership) Reporter() StatusReporter {
+	return o.reporter
+}
+
 type loader struct {
 	unloaded iox.AsyncCloser
 	load     iox.AsyncCloser
@@ -213,4 +226,33 @@ func (u *unloader) load() {
 
 func (u *unloader) unloaded() iox.RAsyncCloser {
 	return u.unload
+}
+
+type statusReporter struct {
+	iox.AsyncCloser
+	loadChan chan Load
+}
+
+func newStatusReporter() *statusReporter {
+	return &statusReporter{
+		AsyncCloser: iox.NewAsyncCloser(),
+		loadChan:    make(chan Load, 100),
+	}
+}
+
+func (s *statusReporter) ReportLoad(load Load) error {
+	if s.IsClosed() {
+		return errReporterClosed
+	}
+
+	select {
+	case s.loadChan <- load:
+		return nil
+	default:
+		return errBufferFull
+	}
+}
+
+func (s *statusReporter) loads() <-chan Load {
+	return s.loadChan
 }

--- a/pkg/model/workpool.go
+++ b/pkg/model/workpool.go
@@ -26,6 +26,7 @@ import (
 const (
 	statsDuration            = 15 * time.Second
 	consumerGrantLogInterval = 10 * time.Minute
+	reportLoadBatchSize      = 1000
 )
 
 var (
@@ -68,9 +69,10 @@ type workPool struct {
 	handler Handler
 	opts    Options
 
-	status *joinStatus            // coordinator connectivity status
-	in     <-chan ConsumerMessage // coordinator incoming messages (empty and not closed, if disconnected)
-	out    chan<- ConsumerMessage // coordinator outgoing messages (empty and not closed, if disconnected)
+	status   *joinStatus            // coordinator connectivity status
+	in       <-chan ConsumerMessage // coordinator incoming messages (empty and not closed, if disconnected)
+	out      chan<- ConsumerMessage // coordinator outgoing messages (empty and not closed, if disconnected)
+	loadChan chan ShardLoad         // range incoming loads (empty and not closed, if disconnected)
 
 	stats workPoolStats
 
@@ -103,6 +105,7 @@ func newWorkPool(consumer Consumer, service QualifiedServiceName, domains []Qual
 		handler:       handlerFn,
 		opts:          opts,
 		poolOptions:   poolOpts,
+		loadChan:      make(chan ShardLoad, reportLoadBatchSize),
 		cluster:       NewClusterMap(NewClusterID(consumer.Instance(), time.Now()), nil), // empty self-origin map
 		clusters:      make(chan Cluster, 1),
 		grants:        map[GrantID]*grant{},
@@ -259,6 +262,19 @@ steady:
 			}
 			p.handleMessage(ctx, msg)
 			p.stopDisconnectTimer()
+
+		case shard := <-p.loadChan:
+
+			// batch forward loads to coordinator
+			shards := []ShardLoad{shard}
+
+			for _, elm := range read(p.loadChan, reportLoadBatchSize-1) {
+				shards = append(shards, elm)
+			}
+
+			if !p.trySend(ctx, NewShardLoadMessage(shards)) {
+				log.Warnf(ctx, "Failed to send load workpool: chan is full")
+			}
 
 		case <-p.expire:
 			p.checkExpiration(ctx)
@@ -485,6 +501,29 @@ func (p *workPool) handleClientMessage(ctx context.Context, msg ClientMessage) {
 					})
 				case <-p.Closed():
 					h.Close()
+				}
+			}()
+
+			go func() {
+				loads := h.ownership.reporter.loads()
+				for !h.IsClosed() {
+					select {
+					case load, ok := <-loads:
+						if !ok {
+							return
+						}
+
+						select {
+						case p.loadChan <- NewShardLoad(g.ID(), load):
+						default:
+							log.Warnf(ctx, "Failed to send load workpool: chan is full")
+						}
+
+					case <-h.Closed():
+						return
+					case <-ctx.Done():
+						return
+					}
 				}
 			}()
 
@@ -840,4 +879,21 @@ func (p *workPool) logGrants(ctx context.Context) {
 
 func newWorkPoolContext(ctx context.Context, consumer Consumer, service QualifiedServiceName) context.Context {
 	return log.NewContext(NewConsumerContext(ctx, consumer), log.String("tenant", service.Tenant), log.String("service", service.Service))
+}
+
+// read reads chan elements to a slice if any, up to count elements. Non-blocking.
+func read[T any](ch <-chan T, count int) []T {
+	var ret []T
+	for len(ret) < count {
+		select {
+		case elm, ok := <-ch:
+			if !ok {
+				return ret
+			}
+			ret = append(ret, elm)
+		default:
+			return ret
+		}
+	}
+	return ret
 }

--- a/pkg/model/workpool_test.go
+++ b/pkg/model/workpool_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.atoms.co/iox"
 	"go.atoms.co/lib/chanx"
@@ -631,6 +632,129 @@ func TestWorkpool(t *testing.T) {
 		done.Close()
 	})
 
+}
+
+func TestWorkpoolReportsLoad(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		loads []Load
+	}{
+		{
+			name:  "reports grant load",
+			loads: []Load{42},
+		},
+		{
+			name:  "reports consecutive grant loads",
+			loads: []Load{10, 20, 30},
+		},
+	} {
+		synctestx.Run(t, tc.name, func(t *testing.T) {
+			coordinatorCon := newFakeCon[ConsumerMessage]()
+			defer coordinatorCon.Close()
+
+			ownerships := make(chan Ownership, 1)
+			consumer := NewInstance(location.NewInstance(location.New("centralus", "pod1")), "endpoint")
+			w, _ := newTestWorkPool(consumer, service1, []QualifiedDomainName{domain1},
+				func(ctx context.Context, self location.Instance, handler grpcx.Handler[ConsumerMessage, ConsumerMessage]) error {
+					return coordinatorCon.connect(ctx, handler)
+				},
+				func(ctx context.Context, id GrantID, shard Shard, ownership Ownership) {
+					ownerships <- ownership
+					<-ctx.Done()
+				},
+				&workPoolOptions{drainTimeout: time.Second},
+			)
+			defer func() {
+				w.Drain()
+				<-w.Closed()
+			}()
+
+			<-coordinatorCon.Connected.Closed()
+			requirex.Element(t, coordinatorCon.In)                       // register
+			coordinatorCon.Out <- NewExtend(time.Now().Add(time.Minute)) // initial extend
+
+			shard := Shard{Domain: domain1, Type: Unit}
+			grant := NewGrant("grant1", shard, ActiveGrantState, time.Now().Add(time.Minute), time.Now())
+			coordinatorCon.Out <- NewAssign(grant)
+			ownership := requirex.Element(t, ownerships)
+
+			for _, load := range tc.loads {
+				assert.NoError(t, ownership.Reporter().ReportLoad(load))
+			}
+
+			reported := make([]ShardLoad, 0, len(tc.loads))
+			for len(reported) < len(tc.loads) {
+				msg := requirex.Element(t, coordinatorCon.In)
+				clientMsg, ok := msg.ClientMessage()
+				require.True(t, ok)
+				status, ok := clientMsg.Status()
+				require.True(t, ok)
+				require.True(t, status.HasLoad())
+				reported = append(reported, status.Load().Shards()...)
+			}
+
+			assert.Len(t, reported, len(tc.loads))
+			for i, load := range tc.loads {
+				assert.Equal(t, grant.ID(), reported[i].ID())
+				assert.Equal(t, load, reported[i].Load())
+			}
+		})
+	}
+}
+
+func TestRead(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ch := make(chan int)
+
+		require.Empty(t, read(ch, 1))
+	})
+
+	t.Run("available", func(t *testing.T) {
+		ch := make(chan int, 3)
+		ch <- 1
+		ch <- 2
+
+		require.Equal(t, []int{1, 2}, read(ch, 3))
+	})
+
+	t.Run("limit", func(t *testing.T) {
+		ch := make(chan int, 3)
+		ch <- 1
+		ch <- 2
+		ch <- 3
+
+		require.Equal(t, []int{1, 2}, read(ch, 2))
+		require.Len(t, ch, 1)
+		require.Equal(t, 3, <-ch)
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		ch := make(chan int, 2)
+		ch <- 1
+		ch <- 2
+		close(ch)
+
+		require.Equal(t, []int{1, 2}, read(ch, 3))
+	})
+
+	t.Run("non-positive count", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			count int
+		}{
+			{name: "negative", count: -1},
+			{name: "zero", count: 0},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				ch := make(chan int, 1)
+				ch <- 1
+
+				require.Empty(t, read(ch, tc.count))
+				require.Len(t, ch, 1)
+				require.Equal(t, 1, <-ch)
+			})
+		}
+	})
 }
 
 type fakeCon[T any] struct {

--- a/pkg/testing/model/ownership.go
+++ b/pkg/testing/model/ownership.go
@@ -19,6 +19,8 @@ type Ownership struct {
 	loader   splitter.Loader
 	unloader splitter.Unloader
 
+	reporter splitter.StatusReporter
+
 	expiration time.Time
 }
 
@@ -51,6 +53,8 @@ func NewOwnership(opts ...OwnershipOption) *Ownership {
 		waitingRevoked:  iox.NewAsyncCloser(),
 		expired:         iox.NewAsyncCloser(),
 		waitingExpired:  iox.NewAsyncCloser(),
+
+		reporter: &statusReporter{},
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -115,4 +119,16 @@ func (o *Ownership) RequestRevoke() {
 
 func (o *Ownership) RevokeRequested() iox.RAsyncCloser {
 	return o.revokeRequested
+}
+
+func (o *Ownership) Reporter() splitter.StatusReporter {
+	return o.reporter
+}
+
+type statusReporter struct {
+}
+
+func (s *statusReporter) ReportLoad(_ splitter.Load) error {
+	// no-op
+	return nil
 }


### PR DESCRIPTION
## Summary
This change
- Adds a new struct `StatusReporter` to `Ownership` so that Range could used it to report loads to the coordinator.
- Updates workpool to forward load from `StatusReporter` to the coordinator.
- Adds a new function `Read` in `chanx` to read specified number of elements from a channel.
- Add unit tests to cover above changes.

## Test Plan
Unit test